### PR TITLE
VPP sync client IPv4 and basic routes

### DIFF
--- a/accel-pppd/CMakeLists.txt
+++ b/accel-pppd/CMakeLists.txt
@@ -85,6 +85,9 @@ IF (HAVE_LOGWTMP)
 	ADD_DEFINITIONS(-DHAVE_LOGWTMP)
 ENDIF (HAVE_LOGWTMP)
 
+IF (HAVE_VPP)
+	ADD_DEFINITIONS(-DHAVE_VPP)
+ENDIF (HAVE_VPP)
 
 ADD_SUBDIRECTORY(triton)
 ADD_SUBDIRECTORY(vlan-mon)
@@ -170,6 +173,15 @@ ADD_EXECUTABLE(accel-pppd
 	log.c
 	main.c
 )
+
+IF (HAVE_VPP)
+	TARGET_SOURCES(accel-pppd PRIVATE
+				   vpputils/vpputils.c
+				   vpputils/vpppoe.c
+				   vpputils/vppiputils.c
+	)
+	TARGET_LINK_LIBRARIES(accel-pppd vapiclient vlibapi vlib)
+endif(HAVE_VPP)
 
 # check if we have getcontext/setcontext
 INCLUDE(CheckFunctionExists)

--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -36,6 +36,12 @@
 
 #include "memdebug.h"
 
+#include "ipdb.h"
+
+#include "vpputils.h"
+#include "vpppoe.h"
+#include "vppiputils.h"
+
 #define SID_MAX 65536
 
 #ifndef min
@@ -224,6 +230,23 @@ static void ppp_started(struct ap_session *ses)
 	log_ppp_debug("pppoe: ppp started\n");
 }
 
+#ifdef HAVE_VPP
+int pppoe_terminate(struct ap_session *ses, int hard) {
+	int ret = 0;
+	struct ppp_t *ppp = container_of(ses, typeof(*ppp), ses);
+	struct pppoe_conn_t *conn = container_of(ppp, typeof(*conn), ppp);
+
+	if (ppp->is_vpppoe) {
+		vpp_iproute_flush(ses);
+		vpppoe_sync_del_pppoe_interface(conn->addr, conn->sid);
+	}
+
+	ret = ppp_terminate(ses, hard);
+
+	return ret;
+}
+#endif /* HAVE_VPP */
+
 static void ppp_finished(struct ap_session *ses)
 {
 	struct ppp_t *ppp = container_of(ses, typeof(*ppp), ses);
@@ -237,6 +260,33 @@ static void ppp_finished(struct ap_session *ses)
 		triton_context_call(&conn->ctx, (triton_event_func)disconnect, conn);
 	}
 }
+
+#ifdef HAVE_VPP
+int pppoe_create_vpp_session_interface(struct ap_session *ses) {
+	struct ppp_t *ppp = container_of(ses, typeof(*ppp), ses);
+	struct pppoe_conn_t *conn = container_of(ppp, typeof(*conn), ppp);
+	uint32_t ifindex = -1;
+	int ret = 0;
+
+	if (!ppp->ses.ipv4) {
+		log_error("VPPPOE: VPP requires IPv4 peer address for session initialization");
+		return -1;
+	}
+
+	ret = vpppoe_sync_add_pppoe_interface(conn->addr, &ses->ipv4->peer_addr, conn->sid, &ifindex);
+	if (ret) {
+		return ret;
+	}
+
+	ses->vpp_sw_if_index = ifindex;
+
+	vpppoe_set_feature(ifindex, 0, "ip4-not-enabled", "ip4-unicast");
+	vpppoe_set_feature(ifindex, 0, "ip6-not-enabled", "ip6-unicast");
+	vpp_iproute_add_del(ses, 1, ifindex, 0, ses->ipv4->peer_addr, 0, ETH_P_ALL, 32, 0);
+
+	return 0;
+}
+#endif /* HAVE_VPP */
 
 static void pppoe_conn_close(struct triton_context_t *ctx)
 {
@@ -348,7 +398,11 @@ static struct pppoe_conn_t *allocate_channel(struct pppoe_serv_t *serv, const ui
 	conn->ctrl.ctx = &conn->ctx;
 	conn->ctrl.started = ppp_started;
 	conn->ctrl.finished = ppp_finished;
+#ifdef HAVE_VPP
+	conn->ctrl.terminate = pppoe_terminate;
+#else
 	conn->ctrl.terminate = ppp_terminate;
+#endif /* HAVE_VPP */
 	conn->ctrl.max_mtu = min(ETH_DATA_LEN, serv->mtu) - 8;
 	conn->ctrl.type = CTRL_TYPE_PPPOE;
 	conn->ctrl.ppp = 1;
@@ -414,6 +468,14 @@ static struct pppoe_conn_t *allocate_channel(struct pppoe_serv_t *serv, const ui
 			addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
 
 	ppp_init(&conn->ppp);
+
+#ifdef HAVE_VPP
+	if (serv->is_vpppoe) {
+		conn->ctrl.dont_ifcfg = 1;
+		conn->ppp.is_vpppoe = 1;
+		conn->ppp.ses.non_dev_ppp_fixup = pppoe_create_vpp_session_interface;
+	}
+#endif /* HAVE_VPP */
 
 	conn->ppp.ses.net = serv->net;
 	conn->ppp.ses.ctrl = &conn->ctrl;
@@ -1331,10 +1393,13 @@ static void pppoe_serv_timeout(struct triton_timer_t *t)
 	pppoe_server_free(serv);
 }
 
-static int parse_server(const char *opt, int *padi_limit, struct ap_net **net)
+static int parse_server(const char *opt, int *padi_limit, struct ap_net **net, int *is_vpppoe)
 {
 	char *ptr, *endptr;
-	char name[64];
+	char optval[64];
+
+	if (is_vpppoe)
+		*is_vpppoe = 0;
 
 	while (*opt == ',') {
 		opt++;
@@ -1349,13 +1414,22 @@ static int parse_server(const char *opt, int *padi_limit, struct ap_net **net)
 		} else if (!strncmp(opt, "net=", sizeof("net=") - 1)) {
 			ptr++;
 			for (endptr = ptr + 1; *endptr && *endptr != ','; endptr++);
-			if (endptr - ptr >= sizeof(name))
+			if (endptr - ptr >= sizeof(optval))
 				goto out_err;
-			memcpy(name, ptr, endptr - ptr);
-			name[endptr - ptr] = 0;
-			*net = ap_net_find(name);
+			memcpy(optval, ptr, endptr - ptr);
+			optval[endptr - ptr] = 0;
+			*net = ap_net_find(optval);
 			if (!*net)
 				goto out_err;
+		} else if (!strncmp(opt, "vpp-cp=", sizeof("vpp-cp=") - 1)) {
+			ptr++;
+			for (endptr = ptr + 1; *endptr && *endptr != ','; endptr++);
+			memcpy(optval, ptr, endptr - ptr);
+			optval[endptr - ptr] = 0;
+			if (is_vpppoe)
+				*is_vpppoe = !strncasecmp(optval, "enable", sizeof("enable") - 1) ||
+								!strncasecmp(optval, "true", sizeof("true") - 1) ||
+								!strncasecmp(optval, "1", sizeof("1") - 1);
 		} else
 			goto out_err;
 	}
@@ -1447,9 +1521,10 @@ static void __pppoe_server_start(const char *ifname, const char *opt, void *cli,
 	struct pppoe_serv_t *serv;
 	struct ifreq ifr;
 	int padi_limit = conf_padi_limit;
+	int is_vpppoe = 0;
 	net = def_net;
 
-	if (parse_server(opt, &padi_limit, &net)) {
+	if (parse_server(opt, &padi_limit, &net, &is_vpppoe)) {
 		if (cli)
 			cli_sendv(cli, "failed to parse '%s'\r\n", opt);
 		else
@@ -1457,6 +1532,17 @@ static void __pppoe_server_start(const char *ifname, const char *opt, void *cli,
 
 		return;
 	}
+
+#ifndef HAVE_VPP
+	if (is_vpppoe) {
+		if (cli)
+			cli_sendv(cli, "No support for vpp, option vpp-cp invalid for interface %s\r\n", ifname);
+		else
+			log_error("pppoe: No support for vpp, option vpp-cp invalid for interface %s\r\n", ifname);
+
+		return;
+	}
+#endif /* HAVE_VPP */
 
 	pthread_rwlock_rdlock(&serv_lock);
 	list_for_each_entry(serv, &serv_list, entry) {
@@ -1483,6 +1569,13 @@ static void __pppoe_server_start(const char *ifname, const char *opt, void *cli,
 	}
 
 	strncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+
+	serv->is_vpppoe = is_vpppoe;
+
+#ifdef HAVE_VPP
+	if (serv->is_vpppoe)
+		vpp_get();
+#endif /* HAVE_VPP */
 
 	if (net->sock_ioctl(SIOCGIFFLAGS, &ifr)) {
 		if (cli)
@@ -1575,6 +1668,12 @@ static void __pppoe_server_start(const char *ifname, const char *opt, void *cli,
 	return;
 
 out_err:
+
+#ifdef HAVE_VPP
+	if (serv->is_vpppoe)
+		vpp_put();
+#endif /* HAVE_VPP */
+
 	_free(serv);
 }
 
@@ -1627,6 +1726,12 @@ void pppoe_server_free(struct pppoe_serv_t *serv)
 	}
 
 	triton_context_unregister(&serv->ctx);
+
+#ifdef HAVE_VPP
+	if (serv->is_vpppoe)
+		vpp_put();
+#endif /* HAVE_VPP */
+
 	_free(serv->ifname);
 	_free(serv);
 }

--- a/accel-pppd/ctrl/pppoe/pppoe.h
+++ b/accel-pppd/ctrl/pppoe/pppoe.h
@@ -99,6 +99,7 @@ struct pppoe_serv_t
 
 	unsigned int stopping:1;
 	unsigned int vlan_mon:1;
+	unsigned int is_vpppoe:1;
 };
 
 extern int conf_verbose;

--- a/accel-pppd/include/ap_session.h
+++ b/accel-pppd/include/ap_session.h
@@ -120,6 +120,10 @@ struct ap_session
 	uint64_t acct_rx_bytes_i;
 	uint64_t acct_tx_bytes_i;
 	int acct_start;
+
+	int (*non_dev_ppp_fixup)(struct ap_session*);
+	uint32_t vpp_sw_if_index;
+	struct list_head vpp_routes;
 };
 
 struct ap_session_stat

--- a/accel-pppd/include/vppiputils.h
+++ b/accel-pppd/include/vppiputils.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+*/
+
+#ifndef VPPIPUTILS_H
+#define VPPIPUTILS_H
+
+#include <stdint.h>
+#include <netinet/in.h>
+
+struct ap_session;
+int vpp_iproute_add_del(struct ap_session *ses, int is_add, int ifindex, in_addr_t src, in_addr_t dst, in_addr_t gw, int proto, int mask, uint32_t prio);
+
+int vpp_iproute_flush(struct ap_session *ses);
+
+#endif /* VPPIPUTILS_H */

--- a/accel-pppd/include/vpppoe.h
+++ b/accel-pppd/include/vpppoe.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+*/
+
+#ifndef VPPPOE_H
+#define VPPPOE_H
+
+#include <stdint.h>
+#include <netinet/in.h>
+
+int vpppoe_sync_add_pppoe_interface(uint8_t *client_mac, in_addr_t *client_ip, uint16_t session_id, uint32_t *sw_ifindex);
+int vpppoe_sync_del_pppoe_interface(uint8_t *client_mac, uint16_t session_id);
+int vpppoe_set_feature(uint32_t ifindex, int is_enabled, const char *feature, const char *arc);
+
+#endif /* VPPPOE_H */

--- a/accel-pppd/include/vpputils.h
+++ b/accel-pppd/include/vpputils.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+*/
+
+#ifndef VPPUTILS_H
+#define VPPUTILS_H
+
+struct vapi_ctx_s;
+struct vapi_ctx_s * vpp_get_vapi();
+
+void vpp_lock();
+void vpp_unlock();
+
+/* export symbols */
+void vpp_get();
+void vpp_put();
+
+
+#endif /* VPPUTILS_H */

--- a/accel-pppd/ppp/ppp.c
+++ b/accel-pppd/ppp/ppp.c
@@ -59,6 +59,7 @@ static mempool_t uc_pool;
 
 static int ppp_chan_read(struct triton_md_handler_t*);
 static int ppp_unit_read(struct triton_md_handler_t*);
+static int ppp_chan_and_unit_read(struct triton_md_handler_t*);
 static void init_layers(struct ppp_t *);
 static void _free_layers(struct ppp_t *);
 static void start_first_layer(struct ppp_t *);
@@ -73,6 +74,8 @@ void __export ppp_init(struct ppp_t *ppp)
 	ppp->fd = -1;
 	ppp->chan_fd = -1;
 	ppp->unit_fd = -1;
+	ppp->is_unit_read_enabled = 0;
+	ppp->is_vpppoe = 0;
 
 	ap_session_init(&ppp->ses);
 }
@@ -82,25 +85,31 @@ int __export establish_ppp(struct ppp_t *ppp)
 	if (ap_shutdown)
 		return -1;
 
-	/* Open an instance of /dev/ppp and connect the channel to it */
-	if (net->ppp_ioctl(ppp->fd, PPPIOCGCHAN, &ppp->chan_idx) == -1) {
-		log_ppp_error("ioctl(PPPIOCGCHAN): %s\n", strerror(errno));
-		return -1;
-	}
+	if (ppp->is_vpppoe) {
+		/* use fd as chan_fd mostly for sending chan packets */
+		ppp->chan_fd = ppp->fd;
+		net->set_nonblocking(ppp->fd, 1);
+	} else {
+		/* Open an instance of /dev/ppp and connect the channel to it */
+		if (net->ppp_ioctl(ppp->fd, PPPIOCGCHAN, &ppp->chan_idx) == -1) {
+			log_ppp_error("ioctl(PPPIOCGCHAN): %s\n", strerror(errno));
+			return -1;
+		}
 
-	ppp->chan_fd = net->ppp_open();
-	if (ppp->chan_fd < 0) {
-		log_ppp_error("open(chan) /dev/ppp: %s\n", strerror(errno));
-		return -1;
-	}
+		ppp->chan_fd = net->ppp_open();
+		if (ppp->chan_fd < 0) {
+			log_ppp_error("open(chan) /dev/ppp: %s\n", strerror(errno));
+			return -1;
+		}
 
-	fcntl(ppp->chan_fd, F_SETFD, fcntl(ppp->chan_fd, F_GETFD) | FD_CLOEXEC);
+		fcntl(ppp->chan_fd, F_SETFD, fcntl(ppp->chan_fd, F_GETFD) | FD_CLOEXEC);
 
-	net->set_nonblocking(ppp->chan_fd, 1);
+		net->set_nonblocking(ppp->chan_fd, 1);
 
-	if (net->ppp_ioctl(ppp->chan_fd, PPPIOCATTCHAN, &ppp->chan_idx) < 0) {
-		log_ppp_error("ioctl(PPPIOCATTCHAN): %s\n", strerror(errno));
-		goto exit_close_chan;
+		if (net->ppp_ioctl(ppp->chan_fd, PPPIOCATTCHAN, &ppp->chan_idx) < 0) {
+			log_ppp_error("ioctl(PPPIOCATTCHAN): %s\n", strerror(errno));
+			goto exit_close_chan;
+		}
 	}
 
 	init_layers(ppp);
@@ -110,7 +119,12 @@ int __export establish_ppp(struct ppp_t *ppp)
 	}
 
 	ppp->chan_hnd.fd = ppp->chan_fd;
-	ppp->chan_hnd.read = ppp_chan_read;
+
+	/* Use combined read for non-dev-ppp*/
+	if (ppp->is_vpppoe)
+		ppp->chan_hnd.read = ppp_chan_and_unit_read;
+	else 
+		ppp->chan_hnd.read = ppp_chan_read;
 
 	if (conf_unit_preallocate) {
 		if (connect_ppp_channel(ppp))
@@ -129,7 +143,12 @@ int __export establish_ppp(struct ppp_t *ppp)
 	return 0;
 
 exit_close_chan:
-	close(ppp->chan_fd);
+	if (!ppp->is_vpppoe) {
+		close(ppp->chan_fd);
+	}
+
+	ppp->chan_fd = -1;
+	ppp->chan_hnd.fd = -1;
 
 	return -1;
 }
@@ -140,12 +159,12 @@ int __export connect_ppp_channel(struct ppp_t *ppp)
 	struct ifreq ifr;
 
 	if (ppp->unit_fd != -1) {
-		if (setup_ppp_mru(ppp))
+		if (!ppp->is_vpppoe && setup_ppp_mru(ppp))
 			goto exit_close_unit;
 		return 0;
 	}
 
-	if (uc_size) {
+	if (!ppp->is_vpppoe && uc_size) {
 		pthread_mutex_lock(&uc_lock);
 		if (!list_empty(&uc_list)) {
 			uc = list_entry(uc_list.next, typeof(*uc), entry);
@@ -155,7 +174,9 @@ int __export connect_ppp_channel(struct ppp_t *ppp)
 		pthread_mutex_unlock(&uc_lock);
 	}
 
-	if (uc) {
+	if (ppp->is_vpppoe) {
+		ppp->unit_fd = ppp->fd;
+	} else if (uc) {
 		ppp->unit_fd = uc->fd;
 		ppp->ses.unit_idx = uc->unit_idx;
 		mempool_free(uc);
@@ -179,39 +200,45 @@ int __export connect_ppp_channel(struct ppp_t *ppp)
 		}
 	}
 
-	if (net->ppp_ioctl(ppp->chan_fd, PPPIOCCONNECT, &ppp->ses.unit_idx) < 0) {
-		log_ppp_error("ioctl(PPPIOCCONNECT): %s\n", strerror(errno));
-		goto exit_close_unit;
+	if (ppp->is_vpppoe) {
+		ppp->ses.ifindex = -1;
+		ppp->is_unit_read_enabled = 1;
+	} else {
+		if (net->ppp_ioctl(ppp->chan_fd, PPPIOCCONNECT, &ppp->ses.unit_idx) < 0) {
+			log_ppp_error("ioctl(PPPIOCCONNECT): %s\n", strerror(errno));
+			goto exit_close_unit;
+		}
+
+		sprintf(ppp->ses.ifname, "ppp%i", ppp->ses.unit_idx);
+
+		log_ppp_info1("connect: %s <--> %s(%s)\n", ppp->ses.ifname, ppp->ses.ctrl->name, ppp->ses.chan_name);
+
+		memset(&ifr, 0, sizeof(ifr));
+		strcpy(ifr.ifr_name, ppp->ses.ifname);
+		if (net->sock_ioctl(SIOCGIFINDEX, &ifr)) {
+			log_ppp_error("ioctl(SIOCGIFINDEX): %s\n", strerror(errno));
+			goto exit_close_unit;
+		}
+		ppp->ses.ifindex = ifr.ifr_ifindex;
+
+		setup_ppp_mru(ppp);
+
+		ap_session_set_ifindex(&ppp->ses);
+
+		ppp->unit_hnd.fd = ppp->unit_fd;
+		ppp->unit_hnd.read = ppp_unit_read;
+
+		log_ppp_debug("ppp connected\n");
+
+		triton_md_register_handler(ppp->ses.ctrl->ctx, &ppp->unit_hnd);
+		triton_md_enable_handler(&ppp->unit_hnd, MD_MODE_READ);
 	}
-
-	sprintf(ppp->ses.ifname, "ppp%i", ppp->ses.unit_idx);
-
-	log_ppp_info1("connect: %s <--> %s(%s)\n", ppp->ses.ifname, ppp->ses.ctrl->name, ppp->ses.chan_name);
-
-	memset(&ifr, 0, sizeof(ifr));
-	strcpy(ifr.ifr_name, ppp->ses.ifname);
-	if (net->sock_ioctl(SIOCGIFINDEX, &ifr)) {
-		log_ppp_error("ioctl(SIOCGIFINDEX): %s\n", strerror(errno));
-		goto exit_close_unit;
-	}
-	ppp->ses.ifindex = ifr.ifr_ifindex;
-
-	setup_ppp_mru(ppp);
-
-	ap_session_set_ifindex(&ppp->ses);
-
-	ppp->unit_hnd.fd = ppp->unit_fd;
-	ppp->unit_hnd.read = ppp_unit_read;
-
-	log_ppp_debug("ppp connected\n");
-
-	triton_md_register_handler(ppp->ses.ctrl->ctx, &ppp->unit_hnd);
-	triton_md_enable_handler(&ppp->unit_hnd, MD_MODE_READ);
 
 	return 0;
 
 exit_close_unit:
-	close(ppp->unit_fd);
+	if (!ppp->is_vpppoe)
+		close(ppp->unit_fd);
 	ppp->unit_fd = -1;
 exit:
 	return -1;
@@ -219,7 +246,8 @@ exit:
 
 static void destroy_ppp_channel(struct ppp_t *ppp)
 {
-	triton_md_unregister_handler(&ppp->chan_hnd, 1);
+	/* do not close chan_hnd.fd if its non-dev-ppp(chan_hnd.fd == ppp.fd) */
+	triton_md_unregister_handler(&ppp->chan_hnd, !ppp->is_vpppoe);
 	close(ppp->fd);
 	ppp->fd = -1;
 	ppp->chan_fd = -1;
@@ -269,6 +297,11 @@ static void destablish_ppp(struct ppp_t *ppp)
 		return;
 	}
 
+	if (ppp->is_vpppoe) {
+		ppp->is_unit_read_enabled = 0;
+		goto skip;
+	}
+
 	if (conf_unit_cache) {
 		struct ifreq ifr;
 
@@ -312,7 +345,7 @@ skip:
 
 	log_ppp_debug("ppp destablished\n");
 
-	if (uc) {
+	if (!ppp->is_vpppoe && uc) {
 		pthread_mutex_lock(&uc_lock);
 		list_add_tail(&uc->entry, &uc_list);
 		if (++uc_size > conf_unit_cache)
@@ -487,6 +520,69 @@ cont:
 		}
 		lcp_send_proto_rej(ppp, proto);
 		//log_ppp_warn("ppp_unit_read: discarding unknown packet %x\n", proto);
+	}
+
+	mempool_free(ppp->buf);
+	ppp->buf = NULL;
+
+	return 0;
+}
+
+static int ppp_chan_and_unit_read(struct triton_md_handler_t *h) {
+	struct ppp_t *ppp = container_of(h, typeof(*ppp), chan_hnd);
+	struct ppp_handler_t *ppp_h;
+	uint16_t proto;
+
+	if (!ppp->buf)
+		ppp->buf = mempool_alloc(buf_pool);
+
+	while(1) {
+cont:
+		ppp->buf_size = net->read(h->fd, ppp->buf, PPP_BUF_SIZE);
+		if (ppp->buf_size < 0) {
+			if (errno != EAGAIN) {
+				log_ppp_error("ppp_chan_and_unit_read: %s\n", strerror(errno));
+				ap_session_terminate(&ppp->ses, TERM_NAS_ERROR, 1);
+				return 1;
+			}
+			break;
+		}
+
+		if (ppp->buf_size == 0)
+			break;
+
+		if (ppp->buf_size < 2) {
+			log_ppp_error("ppp_chan_and_unit_read: short read %i\n", ppp->buf_size);
+			continue;
+		}
+
+		proto = ntohs(*(uint16_t*)ppp->buf);
+		list_for_each_entry(ppp_h, &ppp->chan_handlers, entry) {
+			if (ppp_h->proto == proto) {
+				ppp_h->recv(ppp_h);
+				if (ppp->fd == -1) {
+					ppp->ses.ctrl->finished(&ppp->ses);
+					return 1;
+				}
+				goto cont;
+			}
+		}
+
+		if (ppp->is_unit_read_enabled > 0) {
+			list_for_each_entry(ppp_h, &ppp->unit_handlers, entry) {
+				if (ppp_h->proto == proto) {
+					ppp_h->recv(ppp_h);
+					if (ppp->fd == -1) {
+						ppp->ses.ctrl->finished(&ppp->ses);
+						return 1;
+					}
+					goto cont;
+				}
+			}
+		}
+
+		lcp_send_proto_rej(ppp, proto);
+		log_ppp_warn("ppp_chan_and_unit_read: discarding unknown packet %x\n", proto);
 	}
 
 	mempool_free(ppp->buf);

--- a/accel-pppd/ppp/ppp.h
+++ b/accel-pppd/ppp/ppp.h
@@ -61,6 +61,20 @@ struct ppp_t
 	struct list_head unit_handlers;
 
 	struct list_head layers;
+
+	/** 
+ 	 * In non-dev-ppp environment, channel and unit reads would be performed
+	 * through the same socket and will use the same handler/function.
+	 * This flag sets that additionally unit handlers would be used.
+	 */
+	int is_unit_read_enabled;
+
+	/**
+	 * If this flag is set, then the related /dev/ppp routine would be omitted.
+	 * The socket `fd` would be used to read channel and unit data.
+	 * g.e. `establish_ppp()` would not open /dev/ppp
+	 */
+	int is_vpppoe;
 };
 
 struct ppp_layer_t;

--- a/accel-pppd/ppp/ppp_ccp.c
+++ b/accel-pppd/ppp/ppp_ccp.c
@@ -139,7 +139,8 @@ int ccp_layer_start(struct ppp_layer_data_t *ld)
 
 	log_ppp_debug("ccp_layer_start\n");
 
-	ccp_set_flags(ccp->ppp->unit_fd, 0, 0);
+	if (!ccp->ppp->is_vpppoe)
+		ccp_set_flags(ccp->ppp->unit_fd, 0, 0);
 
 	if (list_empty(&ccp->options) || !conf_ccp) {
 		ccp->started = 1;
@@ -155,7 +156,7 @@ int ccp_layer_start(struct ppp_layer_data_t *ld)
 			return -1;
 	}
 
-	if (ccp_set_flags(ccp->ppp->unit_fd, 1, 0)) {
+	if (!ccp->ppp->is_vpppoe && ccp_set_flags(ccp->ppp->unit_fd, 1, 0)) {
 		ppp_fsm_close(&ccp->fsm);
 		return -1;
 	}
@@ -169,7 +170,8 @@ void ccp_layer_finish(struct ppp_layer_data_t *ld)
 
 	log_ppp_debug("ccp_layer_finish\n");
 
-	ccp_set_flags(ccp->ppp->unit_fd, 0, 0);
+	if (!ccp->ppp->is_vpppoe)
+		ccp_set_flags(ccp->ppp->unit_fd, 0, 0);
 
 	ccp->fsm.fsm_state = FSM_Closed;
 
@@ -197,7 +199,7 @@ static void ccp_layer_up(struct ppp_fsm_t *fsm)
 	if (!ccp->started) {
 		log_ppp_debug("ccp_layer_started\n");
 		ccp->started = 1;
-		if (ccp_set_flags(ccp->ppp->unit_fd, 1, 1)) {
+		if (!ccp->ppp->is_vpppoe && ccp_set_flags(ccp->ppp->unit_fd, 1, 1)) {
 			ap_session_terminate(&ccp->ppp->ses, TERM_NAS_ERROR, 0);
 			return;
 		}

--- a/accel-pppd/session.c
+++ b/accel-pppd/session.c
@@ -76,6 +76,10 @@ void __export ap_session_init(struct ap_session *ses)
 	ses->ifindex = -1;
 	ses->unit_idx = -1;
 	ses->net = net;
+
+	ses->non_dev_ppp_fixup = NULL;
+	ses->vpp_sw_if_index = -1;
+	INIT_LIST_HEAD(&ses->vpp_routes);
 }
 
 void __export ap_session_set_ifindex(struct ap_session *ses)
@@ -149,6 +153,13 @@ void __export ap_session_activate(struct ap_session *ses)
 {
 	if (ap_shutdown)
 		return;
+
+	if (ses->non_dev_ppp_fixup != NULL) {
+		if (ses->non_dev_ppp_fixup(ses)) {
+			ap_session_terminate(ses, TERM_NAS_ERROR, 0);
+			return;
+		}
+	}
 
 	ap_session_ifup(ses);
 

--- a/accel-pppd/vpputils/vppiputils.c
+++ b/accel-pppd/vpputils/vppiputils.c
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+*/
+
+#include <vapi/ip.api.vapi.h>
+
+#include "ap_session.h"
+#include "triton.h"
+#include "vpputils.h"
+
+#include "vppiputils.h"
+
+#include <stdio.h>
+
+DEFINE_VAPI_MSG_IDS_IP_API_JSON
+
+struct vpp_route_t {
+	struct list_head entry;
+	in_addr_t dst;
+	int mask;
+};
+
+static vapi_error_e vpp_ip_ro_cb(struct vapi_ctx_s *ctx,
+								void *callback_ctx,
+ 								vapi_error_e rv,
+								bool is_last,
+								vapi_payload_ip_route_add_del_reply *reply)
+{
+	return VAPI_OK;
+}
+
+__export int vpp_iproute_add_del(struct ap_session *ses, int is_add, int ifindex, in_addr_t src,
+								 in_addr_t dst, in_addr_t gw, int proto, int mask, uint32_t prio)
+{
+	vapi_msg_ip_route_add_del *req = vapi_alloc_ip_route_add_del(vpp_get_vapi(), 1);
+
+	req->payload.is_add = is_add;
+	req->payload.is_multipath = 0;
+	req->payload.route.prefix.address.af = ADDRESS_IP4;
+	memcpy(req->payload.route.prefix.address.un.ip4, &dst, sizeof(dst));
+	req->payload.route.prefix.len = mask;
+	req->payload.route.paths[0].sw_if_index = ifindex;
+
+	vpp_lock();
+	vapi_ip_route_add_del(vpp_get_vapi(), req, vpp_ip_ro_cb, NULL);
+	vpp_unlock();
+
+	if (is_add) {
+		struct vpp_route_t *saved_route = (struct vpp_route_t *)malloc(sizeof(*saved_route));
+		memcpy(&saved_route->dst, &dst, sizeof(dst));
+		saved_route->mask = mask;
+		list_add_tail(&saved_route->entry, &ses->vpp_routes);
+	}
+
+	return 0;
+}
+
+__export int vpp_iproute_flush(struct ap_session *ses)
+{
+	struct list_head *pos, *n;
+
+	list_for_each_safe(pos, n, &ses->vpp_routes) {
+		struct vpp_route_t *saved_route = list_entry(pos, typeof(*saved_route), entry);
+		vpp_iproute_add_del(ses, 0, ses->vpp_sw_if_index, 0, saved_route->dst, 0, 0, saved_route->mask, 0);
+		list_del(&saved_route->entry);
+		free(saved_route);
+	}
+
+	return 0;
+}

--- a/accel-pppd/vpputils/vpppoe.c
+++ b/accel-pppd/vpputils/vpppoe.c
@@ -1,0 +1,124 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+*/
+
+#include <vapi/vapi.h>
+#include <vapi/vpe.api.vapi.h>
+#include <vapi/pppoe.api.vapi.h>
+#include <vapi/feature.api.vapi.h>
+
+#include <linux/if_ether.h>
+
+#include <memory.h>
+#include <stdio.h>
+
+#include "triton.h"
+#include "vpputils.h"
+#include "vpppoe.h"
+
+DEFINE_VAPI_MSG_IDS_VPE_API_JSON
+DEFINE_VAPI_MSG_IDS_PPPOE_API_JSON
+DEFINE_VAPI_MSG_IDS_FEATURE_API_JSON
+
+static vapi_error_e vpppoe_s_session_add_reply_callback(struct vapi_ctx_s *ctx,
+														void *callback_ctx,
+														vapi_error_e rv,
+														bool is_last,
+														vapi_payload_pppoe_add_del_session_reply *reply)
+{
+	uint32_t *sw_ifindex = (uint32_t *)callback_ctx;
+	if (rv == VAPI_OK) {
+		if (sw_ifindex) {
+			*sw_ifindex = reply->sw_if_index;
+		}
+	}
+
+	return rv;
+}
+
+__export int vpppoe_sync_add_pppoe_interface(uint8_t *client_mac, in_addr_t *client_ip, uint16_t session_id, uint32_t *sw_ifindex)
+{
+	vapi_error_e err;
+
+	vapi_msg_pppoe_add_del_session *req = vapi_alloc_pppoe_add_del_session(vpp_get_vapi());
+	if (req == NULL) {
+		return -1;
+	}
+
+	req->payload.client_ip.af = ADDRESS_IP4;
+	memcpy(req->payload.client_ip.un.ip4, client_ip, sizeof(*client_ip));
+	memcpy(req->payload.client_mac, client_mac, ETH_ALEN);
+
+	req->payload.is_add = 1;
+	req->payload.session_id = session_id;
+	req->payload.disable_fib = 1;
+
+	vpp_lock();
+	err = vapi_pppoe_add_del_session(vpp_get_vapi(), req, vpppoe_s_session_add_reply_callback, sw_ifindex);
+	vpp_unlock();
+
+	return err;
+}
+
+static vapi_error_e vpppoe_s_session_del_reply_callback(struct vapi_ctx_s *ctx,
+														void *callback_ctx,
+														vapi_error_e rv,
+														bool is_last,
+														vapi_payload_pppoe_add_del_session_reply *reply)
+{
+	return rv;
+}
+
+__export int vpppoe_sync_del_pppoe_interface(uint8_t *client_mac, uint16_t session_id)
+{
+	vapi_error_e err;
+
+	vapi_msg_pppoe_add_del_session *req = vapi_alloc_pppoe_add_del_session(vpp_get_vapi());
+	if (req == NULL) {
+		return -1;
+	}
+
+	req->payload.client_ip.af = ADDRESS_IP4;
+	memcpy(req->payload.client_mac, client_mac, ETH_ALEN);
+
+	req->payload.is_add = 0;
+	req->payload.session_id = session_id;
+	req->payload.disable_fib = 1;
+
+	vpp_lock();
+	err = vapi_pppoe_add_del_session(vpp_get_vapi(), req, vpppoe_s_session_del_reply_callback, NULL);
+	vpp_unlock();
+
+	return err;
+}
+
+static vapi_error_e vpppoe_set_feature_callback(struct vapi_ctx_s *ctx,
+												void *callback_ctx,
+												vapi_error_e rv,
+												bool is_last,
+												vapi_payload_feature_enable_disable_reply *reply)
+{
+	return rv;
+}
+
+__export int vpppoe_set_feature(uint32_t ifindex, int is_enabled, const char *feature, const char *arc)
+{
+	vapi_error_e err;
+	vapi_msg_feature_enable_disable *req = vapi_alloc_feature_enable_disable(vpp_get_vapi());
+	if (req == NULL)
+		return -1;
+
+	strlcpy((char *)req->payload.feature_name, feature, 64);
+	strlcpy((char *)req->payload.arc_name, arc, 64);
+
+	req->payload.sw_if_index = ifindex;
+	req->payload.enable = is_enabled;
+
+	vpp_lock();
+	err = vapi_feature_enable_disable(vpp_get_vapi(), req, vpppoe_set_feature_callback, NULL);
+	vpp_unlock();
+
+	return err;
+}

--- a/accel-pppd/vpputils/vpputils.c
+++ b/accel-pppd/vpputils/vpputils.c
@@ -1,0 +1,100 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+*/
+
+#include <vapi/vapi.h>
+#include <vapi/vpe.api.vapi.h>
+
+#include <pthread.h>
+
+#include "triton.h"
+#include "events.h"
+
+#include "vpputils.h"
+
+int sc_vpp_queue_size = 1024;
+
+struct vpp_connect_t
+{
+	vapi_ctx_t vapi;
+	int rfcounter;
+	pthread_mutex_t lock_vpp;
+} vpp_connect;
+
+const char vpp_app_name[] = "accel-vpp";
+
+static void vpppoe_connect_to_vpp()
+{
+	vapi_error_e verr = vapi_ctx_alloc(&vpp_connect.vapi);
+
+	if (verr != VAPI_OK) {
+		vpp_connect.vapi = NULL;
+		return;
+	}
+
+	verr = vapi_connect_ex(vpp_connect.vapi, vpp_app_name, NULL, sc_vpp_queue_size, sc_vpp_queue_size, VAPI_MODE_BLOCKING, true, true);
+	if (verr != VAPI_OK) {
+		vapi_ctx_free(vpp_connect.vapi);
+		vpp_connect.vapi = NULL;
+		return;
+	}
+
+	pthread_mutex_init(&vpp_connect.lock_vpp, NULL);
+}
+
+void vpppoe_disconnect_from_vpp()
+{
+	pthread_mutex_destroy(&vpp_connect.lock_vpp);
+	vapi_disconnect(vpp_connect.vapi);
+	vapi_ctx_free(vpp_connect.vapi);
+	vpp_connect.vapi = NULL;
+}
+
+struct vapi_ctx_s * vpp_get_vapi() {
+	return vpp_connect.vapi;
+}
+
+void vpp_lock() {
+	pthread_mutex_lock(&vpp_connect.lock_vpp);
+}
+
+void vpp_unlock() {
+	pthread_mutex_unlock(&vpp_connect.lock_vpp);
+}
+
+void __export vpp_get()
+{
+	int rfc = __sync_fetch_and_add(&vpp_connect.rfcounter, 1);
+	if (!rfc)
+		vpppoe_connect_to_vpp();
+}
+
+void __export vpp_put()
+{
+	int rfc = __sync_sub_and_fetch(&vpp_connect.rfcounter, 1);
+	if (!rfc)
+		vpppoe_disconnect_from_vpp();
+}
+
+
+static void vpppoe_load_config(void)
+{
+	char *opt;
+
+	opt = conf_get_opt("vpp", "queue-size");
+	if (opt)
+		sc_vpp_queue_size = atoi(opt);      
+}
+
+static void vpppoe_init()
+{
+	memset(&vpp_connect, 0, sizeof(vpp_connect));
+
+	vpppoe_load_config();
+
+	triton_event_register_handler(EV_CONFIG_RELOAD, (triton_event_func)vpppoe_load_config);
+}
+
+DEFINE_INIT(20, vpppoe_init);


### PR DESCRIPTION
## Change summary
Added VPP client for accel-ppp.
New option for PPPoE interface ".vpp-cp"(VPP Control Plane).
New option "queue-size" for VPP client queue size.
PPPoE session created in VPP dataplane(without lcp interface pair).
Added route configuration and route list to remove.
Added HAVE_VPP CMake option that enables VPP and vpp-cp routine - VPP libs and header required.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
VD-517

## How to test / Smoketest result
Configure VPP with control plane and lcp pair to it.
Add option vpp-cp in config:

```
[pppoe]
interface=eth0,vpp-cp=true
ip-pool=ONE
```

Use bngblaster for load testing.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
