### PR TITLE
VPP & RADIUS: Added VPP routes routines to the RADIUS client.

### DIFF
--- a/accel-pppd/ctrl/pppoe/cli.c
+++ b/accel-pppd/ctrl/pppoe/cli.c
@@ -14,12 +14,13 @@ static void show_interfaces(void *cli)
 {
 	struct pppoe_serv_t *serv;
 
-	cli_send(cli, "interface:   connections:    state:\r\n");
-	cli_send(cli, "-----------------------------------\r\n");
+	cli_send(cli, "interface:   connections:    state:    vpp-cp:\r\n");
+	cli_send(cli, "----------------------------------------------\r\n");
 
 	pthread_rwlock_rdlock(&serv_lock);
 	list_for_each_entry(serv, &serv_list, entry) {
-		cli_sendv(cli, "%9s    %11u    %6s\r\n", serv->ifname, serv->conn_cnt, serv->stopping ? "stop" : "active");
+		cli_sendv(cli, "%9s    %11u    %6s    %7s\r\n", serv->ifname, serv->conn_cnt, serv->stopping ? "stop" : "active",
+				serv->is_vpppoe ? "enable" : "disable");
 	}
 	pthread_rwlock_unlock(&serv_lock);
 }

--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -268,21 +268,19 @@ int pppoe_create_vpp_session_interface(struct ap_session *ses) {
 	uint32_t ifindex = -1;
 	int ret = 0;
 
-	if (!ppp->ses.ipv4) {
-		log_error("VPPPOE: VPP requires IPv4 peer address for session initialization");
-		return -1;
-	}
-
-	ret = vpppoe_sync_add_pppoe_interface(conn->addr, &ses->ipv4->peer_addr, conn->sid, &ifindex);
+	ret = vpppoe_sync_add_pppoe_interface(conn->addr, conn->sid, &ifindex);
 	if (ret) {
 		return ret;
 	}
 
 	ses->vpp_sw_if_index = ifindex;
+	vpppoe_dump_interface_name(ifindex, ses->ifname, AP_IFNAME_LEN);
 
 	vpppoe_set_feature(ifindex, 0, "ip4-not-enabled", "ip4-unicast");
 	vpppoe_set_feature(ifindex, 0, "ip6-not-enabled", "ip6-unicast");
-	vpp_iproute_add_del(ses, 1, ifindex, 0, ses->ipv4->peer_addr, 0, ETH_P_ALL, 32, 0);
+	if (ppp->ses.ipv4) {
+		vpp_iproute_add_del(ses, 1, ifindex, 0, ses->ipv4->peer_addr, 0, ETH_P_ALL, 32, 0);
+	}
 
 	return 0;
 }
@@ -471,7 +469,6 @@ static struct pppoe_conn_t *allocate_channel(struct pppoe_serv_t *serv, const ui
 
 #ifdef HAVE_VPP
 	if (serv->is_vpppoe) {
-		conn->ctrl.dont_ifcfg = 1;
 		conn->ppp.is_vpppoe = 1;
 		conn->ppp.ses.non_dev_ppp_fixup = pppoe_create_vpp_session_interface;
 	}

--- a/accel-pppd/ifcfg.c
+++ b/accel-pppd/ifcfg.c
@@ -98,6 +98,10 @@ void __export ap_session_accounting_started(struct ap_session *ses)
 	if (ses->stop_time)
 		return;
 
+	/* Skip completely ifcfg routine for non-dev-ppp sessions */
+	if (ses->non_dev_ppp_fixup != NULL)
+		goto skip_ifcfg;
+
 	memset(&ifr, 0, sizeof(ifr));
 	strcpy(ifr.ifr_name, ses->ifname);
 
@@ -188,6 +192,8 @@ void __export ap_session_accounting_started(struct ap_session *ses)
 		}
 #endif
 	}
+
+skip_ifcfg:
 
 	ses->ctrl->started(ses);
 

--- a/accel-pppd/include/ap_session.h
+++ b/accel-pppd/include/ap_session.h
@@ -7,7 +7,7 @@
 #include "ap_net.h"
 
 //#define AP_SESSIONID_LEN 16
-#define AP_IFNAME_LEN 16
+#define AP_IFNAME_LEN 64
 
 #define AP_STATE_STARTING  1
 #define AP_STATE_ACTIVE    2

--- a/accel-pppd/include/vpppoe.h
+++ b/accel-pppd/include/vpppoe.h
@@ -10,8 +10,9 @@
 #include <stdint.h>
 #include <netinet/in.h>
 
-int vpppoe_sync_add_pppoe_interface(uint8_t *client_mac, in_addr_t *client_ip, uint16_t session_id, uint32_t *sw_ifindex);
+int vpppoe_sync_add_pppoe_interface(uint8_t *client_mac, uint16_t session_id, uint32_t *sw_ifindex);
 int vpppoe_sync_del_pppoe_interface(uint8_t *client_mac, uint16_t session_id);
 int vpppoe_set_feature(uint32_t ifindex, int is_enabled, const char *feature, const char *arc);
+int vpppoe_dump_interface_name(uint32_t ifindex, char *name, size_t size);
 
 #endif /* VPPPOE_H */

--- a/accel-pppd/radius/radius.c
+++ b/accel-pppd/radius/radius.c
@@ -24,6 +24,8 @@
 
 #include "memdebug.h"
 
+#include "accel_iputils.h"
+
 int conf_max_try = 3;
 int conf_timeout = 3;
 int conf_acct_timeout = 3;
@@ -653,8 +655,7 @@ static void ses_started(struct ap_session *ses)
 		bool gw_spec = !IN6_IS_ADDR_UNSPECIFIED(&fr6->gw);
 		char nbuf[INET6_ADDRSTRLEN];
 		char gwbuf[INET6_ADDRSTRLEN];
-
-		if (ip6route_add(gw_spec ? 0 : rpd->ses->ifindex, &fr6->prefix, fr6->plen, gw_spec ? &fr6->gw : NULL, 3, fr6->prio, rpd->ses->vrf_name)) {
+		if (accel_ip6route_add(ses, gw_spec ? 0 : rpd->ses->ifindex, &fr6->prefix, fr6->plen, gw_spec ? &fr6->gw : NULL, 3, fr6->prio, rpd->ses->vrf_name)) {
 			log_ppp_warn("radius: failed to add route %s/%hhu %s %u\n",
 							u_ip6str(&fr6->prefix, nbuf), fr6->plen,
 							u_ip6str(&fr6->gw, gwbuf), fr6->prio);
@@ -662,7 +663,7 @@ static void ses_started(struct ap_session *ses)
 	}
 
 	for (fr = rpd->fr; fr; fr = fr->next) {
-		if (iproute_add(fr->gw ? 0 : rpd->ses->ifindex, 0, fr->dst, fr->gw, 3, fr->mask, fr->prio, rpd->ses->vrf_name)) {
+		if (accel_iproute_add(ses, fr->gw ? 0 : rpd->ses->ifindex, 0, fr->dst, fr->gw, 3, fr->mask, fr->prio, rpd->ses->vrf_name)) {
 			char dst[17], gw[17];
 			u_inet_ntoa(fr->dst, dst);
 			u_inet_ntoa(fr->gw, gw);
@@ -701,12 +702,12 @@ static void ses_finishing(struct ap_session *ses)
 		 * when the interface is removed.
 		 */
 		if (!IN6_IS_ADDR_UNSPECIFIED(&fr6->gw))
-			ip6route_del(0, &fr6->prefix, fr6->plen, &fr6->gw, 3, fr6->prio, rpd->ses->vrf_name);
+			accel_ip6route_del(ses, 0, &fr6->prefix, fr6->plen, &fr6->gw, 3, fr6->prio, rpd->ses->vrf_name);
 	}
 
 	for (fr = rpd->fr; fr; fr = fr->next) {
 		if (fr->gw)
-			iproute_del(0, 0, fr->dst, fr->gw, 3, fr->mask, fr->prio, rpd->ses->vrf_name);
+			accel_iproute_del(ses, 0, 0, fr->dst, fr->gw, 3, fr->mask, fr->prio, rpd->ses->vrf_name);
 	}
 
 	if (rpd->acct_started || rpd->acct_req)

--- a/accel-pppd/triton/timer.c
+++ b/accel-pppd/triton/timer.c
@@ -201,6 +201,11 @@ void __export triton_timer_del(struct triton_timer_t *ud)
 {
 	struct _triton_timer_t *t = (struct _triton_timer_t *)ud->tpd;
 
+	if (ud == NULL || t == NULL) {
+		/* double time del? */
+		return;
+	}
+
 	spin_lock(&t->ctx->lock);
 	t->ud = NULL;
 	list_del(&t->entry);

--- a/accel-pppd/vpputils/vpppoe.c
+++ b/accel-pppd/vpputils/vpppoe.c
@@ -2,12 +2,13 @@
 /*
  * Copyright (c) 2025 by VyOS Networks
  * Andrii Melnychenko a.melnychenko@vyos.io
-*/
+ */
 
 #include <vapi/vapi.h>
 #include <vapi/vpe.api.vapi.h>
 #include <vapi/pppoe.api.vapi.h>
 #include <vapi/feature.api.vapi.h>
+#include <vapi/interface.api.vapi.h>
 
 #include <linux/if_ether.h>
 
@@ -21,6 +22,7 @@
 DEFINE_VAPI_MSG_IDS_VPE_API_JSON
 DEFINE_VAPI_MSG_IDS_PPPOE_API_JSON
 DEFINE_VAPI_MSG_IDS_FEATURE_API_JSON
+DEFINE_VAPI_MSG_IDS_INTERFACE_API_JSON
 
 static vapi_error_e vpppoe_s_session_add_reply_callback(struct vapi_ctx_s *ctx,
 														void *callback_ctx,
@@ -38,7 +40,7 @@ static vapi_error_e vpppoe_s_session_add_reply_callback(struct vapi_ctx_s *ctx,
 	return rv;
 }
 
-__export int vpppoe_sync_add_pppoe_interface(uint8_t *client_mac, in_addr_t *client_ip, uint16_t session_id, uint32_t *sw_ifindex)
+__export int vpppoe_sync_add_pppoe_interface(uint8_t *client_mac, uint16_t session_id, uint32_t *sw_ifindex)
 {
 	vapi_error_e err;
 
@@ -48,7 +50,6 @@ __export int vpppoe_sync_add_pppoe_interface(uint8_t *client_mac, in_addr_t *cli
 	}
 
 	req->payload.client_ip.af = ADDRESS_IP4;
-	memcpy(req->payload.client_ip.un.ip4, client_ip, sizeof(*client_ip));
 	memcpy(req->payload.client_mac, client_mac, ETH_ALEN);
 
 	req->payload.is_add = 1;
@@ -123,4 +124,47 @@ __export int vpppoe_set_feature(uint32_t ifindex, int is_enabled, const char *fe
 	vpp_unlock();
 
 	return err;
+}
+
+typedef struct vpppoe_dump_interface_name_ctx_t
+{
+	char *name;
+	size_t size;
+} vpppoe_dump_interface_name_ctx_t;
+
+static vapi_error_e vpppoe_dump_interface_name_callback(struct vapi_ctx_s *ctx,
+											void *callback_ctx,
+											vapi_error_e rv,
+											bool is_last,
+											vapi_payload_sw_interface_details *reply)
+{
+	if (callback_ctx != NULL && reply != NULL && rv == VAPI_OK) {
+		vpppoe_dump_interface_name_ctx_t *ctx = (vpppoe_dump_interface_name_ctx_t *)callback_ctx;
+		strncpy(ctx->name, reply->interface_name, ctx->size > 64 ? 64 : ctx->size);
+		ctx->name[(ctx->size > 64 ? 64 : ctx->size) - 1] = 0;
+	}
+
+	return rv;
+}
+
+__export int vpppoe_dump_interface_name(uint32_t ifindex, char *name, size_t size)
+{
+	vapi_error_e err;
+
+	if (name == NULL || !size) {
+		return -1;
+	}
+
+	/* Allocated in stack - works only with sync VPP client */
+	vpppoe_dump_interface_name_ctx_t ctx = {name, size};
+
+	vapi_msg_sw_interface_dump *req = vapi_alloc_sw_interface_dump(vpp_get_vapi(), 0);
+
+	req->payload.sw_if_index = ifindex;
+
+	vpp_lock();
+	err = vapi_sw_interface_dump(vpp_get_vapi(), req, vpppoe_dump_interface_name_callback, &ctx);
+	vpp_unlock();
+
+	return err != VAPI_OK;
 }


### PR DESCRIPTION
Also, added some quality of life and bugfix changes.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Added client's interface names - dumped from VPP.
Added "vpp-cp"(VPP control plane) stat for "pppoe interface show".
Fixed issue with crash on double timer free(may occur in concurrent session closing).
No more IPv4 is required to create the VPP session. Added "ifcfg" skip for VPP sessions.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
VD-1143

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Start VyOS VPP(with patches for ND&DHCPv6 and modified `vapi_pppoe_add_del_session`)
startup.conf:
```
...
dpdk {
    dev 0000:00:00.0
    dev 0000:09:00.0 {
        name eth0
        }
    uio-bind-force
}

pppoe {
    enable-pass-nd-and-dhcpv6
}
```

VPP commands:
```
vpp# lcp create eth0 host-if eth0
vpp# create pppoe map dp eth0 cp tap4096
```

Configure accel-pppd similar to this:
```
[modules]
radius
...

[pppoe]
interface=eth0,vpp-cp=true
...

[radius]
verbose=1
server=192.168.13.3,vyos-secret,auth-port=1812,acct-port=1813,req-limit=0,fail-time=0
acct-timeout=3
timeout=3
max-try=3
gw-ip-address=100.64.0.1

```

Set up RADIUS server, with VyOS instance, may be something like this:
```
add container image 'dchidell/radius-web'
set container name radius allow-host-networks
set container name radius image 'dchidell/radius-web'
set container name radius volume clients destination '/etc/raddb/clients.conf'
set container name radius volume clients source '/config/containers/radius/clients'
set container name radius volume users destination '/etc/raddb/users'
set container name radius volume users source '/config/containers/radius/users'
```

Add test client to the RADIUS g.e.:
```
client-1	Cleartext-Password := "client-1"
    Service-Type = Framed-User,
    Framed-IP-Address = 10.0.0.11,
    Framed-Route = "100.64.0.11/32 10.0.0.11 1",
    Delegated-IPv6-Prefix := "2001:db8:1313::/56",
    Framed-IPv6-Address := 2001:db8:1313::1,
    Framed-IPv6-Prefix := 2001:db8:1313::/64,
    Framed-IPv6-Route := "2001:db8:1313::/64 2001:db8:1313::1 1",
    Framed-Protocol = PPP
```

Connect with the client, client configuration:
`/etc/ppp/peer/vyos`
```
...
user "client-1"
password "client-1"
usepeerdns
+ipv6 ipv6cp-use-ipaddr

```

Check client and IPv4 and IPv6-dp.:
```
root@dev:/home/dev# pon vyos
Plugin rp-pppoe.so loaded.
root@dev:/home/dev# ip a
...
17: pppoe1: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1492 qdisc fq_codel state UNKNOWN group default qlen 3
    link/ppp 
    inet 10.0.0.11 peer 100.64.0.1/32 scope global pppoe1
       valid_lft forever preferred_lft forever
    inet6 2001:db8:1313:0:68f6:c263:66e4:a10/64 scope global temporary dynamic 
       valid_lft 604792sec preferred_lft 86328sec
    inet6 2001:db8:1313:0:200::/64 scope global dynamic mngtmpaddr 
       valid_lft 2591998sec preferred_lft 604798sec
    inet6 fe80::200:0:0:0 peer fe80::100:0:0:0/128 scope link 
       valid_lft forever preferred_lft forever
root@dev:/home/dev# 
```

Check VPP fibs:
```
vpp# show ip fib
ipv4-VRF:0, fib_index:0, flow hash:[src dst sport dport proto flowlabel ] epoch:0 flags:none locks:[default-route:1, ]
...
10.0.0.11/32
  unicast-ip4-chain
  [@0]: dpo-load-balance: [proto:ip4 index:11 buckets:1 uRPF:9 to:[0:0]]
    [0] [@6]: ipv4 via 0.0.0.0 pppoe_session0: mtu:9000 next:6 flags:[] 5254007bf1d55254002fc4b48864110000c000000021
        stacked-on:
          [@2]: eth0-tx-dpo:
100.64.0.11/32
  unicast-ip4-chain
  [@0]: dpo-load-balance: [proto:ip4 index:13 buckets:1 uRPF:12 to:[0:0]]
    [0] [@6]: ipv4 via 0.0.0.0 pppoe_session0: mtu:9000 next:6 flags:[] 5254007bf1d55254002fc4b48864110000c000000021
        stacked-on:
          [@2]: eth0-tx-dpo:
...
vpp# show ip6 fib
...
2001:db8:1313::/64
  unicast-ip6-chain
  [@0]: dpo-load-balance: [proto:ip6 index:12 buckets:1 uRPF:11 to:[0:0]]
    [0] [@6]: ipv6 via 0.0.0.0 pppoe_session0: mtu:9000 next:6 flags:[] 5254007bf1d55254002fc4b48864110000c000000057
        stacked-on:
          [@2]: eth0-tx-dpo:
...
vpp#
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
