### PR TITLE
VPP: Added event for VPP connection lost and new/del link.

### DIFF
--- a/accel-pppd/CMakeLists.txt
+++ b/accel-pppd/CMakeLists.txt
@@ -161,6 +161,7 @@ ADD_EXECUTABLE(accel-pppd
 	libnetlink/iputils.c
 	libnetlink/genl.c
 	libnetlink/ipset.c
+	libnetlink/new_link_event.c
 
 	pwdb.c
 	ipdb.c

--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -1583,6 +1583,7 @@ static void __pppoe_server_start(const char *ifname, const char *opt, void *cli,
 
 	strncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
 
+	serv->stop_cause = TERM_ADMIN_RESET;
 #ifdef HAVE_VPP
 	serv->is_vpppoe = is_vpppoe;
 	serv->is_vpppoe_lost = 0;
@@ -1697,7 +1698,7 @@ out_err:
 
 static void _conn_stop(struct pppoe_conn_t *conn)
 {
-	ap_session_terminate(&conn->ppp.ses, TERM_ADMIN_RESET, 0);
+	ap_session_terminate(&conn->ppp.ses, conn->serv->stop_cause, 0);
 }
 
 void _server_stop(struct pppoe_serv_t *serv)
@@ -2312,7 +2313,7 @@ static void pppoe_on_add_link(const char *name)
 	pthread_rwlock_unlock(&serv_lock);
 	if (s != NULL) {
 		__pppoe_server_start(s->name, s->opt, NULL, -1, 0, 0);
-		log_info1("pppoe: new link event caught, starting the service on: %s with options \"%s\"\n", s->name, s->opt);
+		log_info1("pppoe: new link event received, starting the service on: %s with options \"%s\"\n", s->name, s->opt);
 	}
 }
 
@@ -2325,8 +2326,9 @@ static void pppoe_on_del_link(const char *name)
 	list_for_each_entry(serv, &serv_list, entry) {
 		if (strcmp(serv->ifname, name) || serv->stopping)
 			continue;
+		serv->stop_cause = TERM_NAS_ERROR;
 		triton_context_call(&serv->ctx, (triton_event_func)_server_stop, serv);
-		log_warn("pppoe: delete link event caught, stopping the service on: %s ifindex %d\n", serv->ifname, serv->ifindex);
+		log_warn("pppoe: delete link event received, stopping the service on: %s ifindex %d\n", serv->ifname, serv->ifindex);
 		break;
 	}
 	pthread_rwlock_unlock(&serv_lock);
@@ -2340,6 +2342,7 @@ static void pppoe_on_vpp_connection_lost(struct vpp_handler_t *h)
 	serv->is_vpppoe_lost = 1;
 
 	/* terminate pppoe service */
+	serv->stop_cause = TERM_NAS_ERROR;
 	triton_context_call(&serv->ctx, (triton_event_func)_server_stop, serv);
 	log_warn("pppoe: VPP connection lost, stopping the service on: %s ifindex %d\n", serv->ifname, serv->ifindex);
 }

--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -41,6 +41,7 @@
 #include "vpputils.h"
 #include "vpppoe.h"
 #include "vppiputils.h"
+#include "new_link_event.h"
 
 #define SID_MAX 65536
 
@@ -142,6 +143,14 @@ static unsigned long *sid_map;
 static unsigned long *sid_ptr;
 static int sid_idx;
 
+struct nnle_handler_t pppoe_nnle_handler;
+LIST_HEAD(monitored_link_list);
+
+static void monitored_link_list_add(const char *name, const char *opt);
+static void monitored_link_list_del(const char *name);
+struct monitored_link_list_entry_t * monitored_link_list_find(const char *name);
+static void pppoe_on_vpp_connection_lost(struct vpp_handler_t *h);
+
 static uint8_t bc_addr[ETH_ALEN] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
 static void pppoe_send_PADT(struct pppoe_conn_t *conn);
@@ -236,7 +245,7 @@ int pppoe_terminate(struct ap_session *ses, int hard) {
 	struct ppp_t *ppp = container_of(ses, typeof(*ppp), ses);
 	struct pppoe_conn_t *conn = container_of(ppp, typeof(*conn), ppp);
 
-	if (ppp->is_vpppoe) {
+	if (ppp->is_vpppoe && !conn->serv->is_vpppoe_lost) {
 		vpp_iproute_flush(ses);
 		vpppoe_sync_del_pppoe_interface(conn->addr, conn->sid);
 	}
@@ -267,6 +276,9 @@ int pppoe_create_vpp_session_interface(struct ap_session *ses) {
 	struct pppoe_conn_t *conn = container_of(ppp, typeof(*conn), ppp);
 	uint32_t ifindex = -1;
 	int ret = 0;
+
+	if (conn->serv->is_vpppoe_lost)
+		return -1;
 
 	ret = vpppoe_sync_add_pppoe_interface(conn->addr, conn->sid, &ifindex);
 	if (ret) {
@@ -1543,13 +1555,17 @@ static void __pppoe_server_start(const char *ifname, const char *opt, void *cli,
 
 	pthread_rwlock_rdlock(&serv_lock);
 	list_for_each_entry(serv, &serv_list, entry) {
-		if (serv->net == net && !strcmp(serv->ifname, ifname)) {
+		if (serv->net == net && !strcmp(serv->ifname, ifname) && !serv->stopping) {
 			if (cli)
 				cli_send(cli, "error: already exists\r\n");
 			pthread_rwlock_unlock(&serv_lock);
 			return;
 		}
 	}
+	pthread_rwlock_unlock(&serv_lock);
+
+	pthread_rwlock_wrlock(&serv_lock);
+	monitored_link_list_add(ifname, opt);
 	pthread_rwlock_unlock(&serv_lock);
 
 	if (vid && !vlan_mon && vlan_mon_check_busy(parent_ifindex, vid))
@@ -1567,11 +1583,14 @@ static void __pppoe_server_start(const char *ifname, const char *opt, void *cli,
 
 	strncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
 
-	serv->is_vpppoe = is_vpppoe;
-
 #ifdef HAVE_VPP
-	if (serv->is_vpppoe)
+	serv->is_vpppoe = is_vpppoe;
+	serv->is_vpppoe_lost = 0;
+	if (serv->is_vpppoe) {
+		serv->vpp_handler.on_vpp_connection_lost = pppoe_on_vpp_connection_lost;
+		vpp_register_handler(&serv->vpp_handler);
 		vpp_get();
+	}
 #endif /* HAVE_VPP */
 
 	if (net->sock_ioctl(SIOCGIFFLAGS, &ifr)) {
@@ -1667,8 +1686,10 @@ static void __pppoe_server_start(const char *ifname, const char *opt, void *cli,
 out_err:
 
 #ifdef HAVE_VPP
-	if (serv->is_vpppoe)
+	if (serv->is_vpppoe) {
+		vpp_unregister_handler(&serv->vpp_handler);
 		vpp_put();
+	}
 #endif /* HAVE_VPP */
 
 	_free(serv);
@@ -1725,8 +1746,10 @@ void pppoe_server_free(struct pppoe_serv_t *serv)
 	triton_context_unregister(&serv->ctx);
 
 #ifdef HAVE_VPP
-	if (serv->is_vpppoe)
+	if (serv->is_vpppoe) {
+		vpp_unregister_handler(&serv->vpp_handler);
 		vpp_put();
+	}
 #endif /* HAVE_VPP */
 
 	_free(serv->ifname);
@@ -1737,9 +1760,13 @@ void pppoe_server_stop(const char *ifname)
 {
 	struct pppoe_serv_t *serv;
 
+	pthread_rwlock_wrlock(&serv_lock);
+	monitored_link_list_del(ifname);
+	pthread_rwlock_unlock(&serv_lock);
+
 	pthread_rwlock_rdlock(&serv_lock);
 	list_for_each_entry(serv, &serv_list, entry) {
-		if (strcmp(serv->ifname, ifname))
+		if (strcmp(serv->ifname, ifname) || serv->stopping)
 			continue;
 		triton_context_call(&serv->ctx, (triton_event_func)_server_stop, serv);
 		break;
@@ -2223,6 +2250,101 @@ static void load_interfaces()
 	}
 }
 
+static void monitored_link_list_add(const char *name, const char *opt)
+{
+	struct monitored_link_list_entry_t *s;
+
+	if (name == NULL) {
+		return;
+	}
+
+	s = monitored_link_list_find(name);
+	/* TODO: update opt? */
+	/* already exists */
+	if (s != NULL)
+		return;
+
+	s = malloc(sizeof(*s));
+	s->name = strdup(name);
+	s->opt = NULL;
+	if (opt)
+		s->opt = strdup(opt);
+
+	list_add_tail(&s->entry, &monitored_link_list);
+}
+
+static void monitored_link_list_del(const char *name)
+{
+	struct monitored_link_list_entry_t *s;
+
+	s = monitored_link_list_find(name);
+	if (s == NULL)
+		return;
+
+	list_del(&s->entry);
+	free(s->name);
+	if (s->opt)
+		free(s->opt);
+
+	free(s);
+}
+
+struct monitored_link_list_entry_t * monitored_link_list_find(const char *name)
+{
+	struct monitored_link_list_entry_t *s;
+
+	if (name == NULL)
+		return NULL;
+
+	list_for_each_entry(s, &monitored_link_list, entry) {
+		if (!strncmp(name, s->name, IFNAMSIZ - 1)) {
+			return s;
+		}
+	}
+
+	return NULL;
+}
+
+static void pppoe_on_add_link(const char *name)
+{
+	pthread_rwlock_rdlock(&serv_lock);
+	struct monitored_link_list_entry_t *s = monitored_link_list_find(name);
+	pthread_rwlock_unlock(&serv_lock);
+	if (s != NULL) {
+		__pppoe_server_start(s->name, s->opt, NULL, -1, 0, 0);
+		log_info1("pppoe: new link event caught, starting the service on: %s with options \"%s\"\n", s->name, s->opt);
+	}
+}
+
+static void pppoe_on_del_link(const char *name)
+{
+	/* TODO: it is a copy of pppoe_server_stop() without monitored delete */
+	struct pppoe_serv_t *serv;
+
+	pthread_rwlock_rdlock(&serv_lock);
+	list_for_each_entry(serv, &serv_list, entry) {
+		if (strcmp(serv->ifname, name) || serv->stopping)
+			continue;
+		triton_context_call(&serv->ctx, (triton_event_func)_server_stop, serv);
+		log_warn("pppoe: delete link event caught, stopping the service on: %s ifindex %d\n", serv->ifname, serv->ifindex);
+		break;
+	}
+	pthread_rwlock_unlock(&serv_lock);
+}
+
+#ifdef HAVE_VPP
+static void pppoe_on_vpp_connection_lost(struct vpp_handler_t *h)
+{
+	struct pppoe_serv_t *serv = container_of(h, typeof(*serv), vpp_handler);
+	/* skip all vpp calls for sessions on this service */
+	serv->is_vpppoe_lost = 1;
+
+	/* terminate pppoe service */
+	triton_context_call(&serv->ctx, (triton_event_func)_server_stop, serv);
+	log_warn("pppoe: VPP connection lost, stopping the service on: %s ifindex %d\n", serv->ifname, serv->ifindex);
+}
+#endif /* HAVE_VPP */
+
 static void pppoe_init(void)
 {
 	int fd;
@@ -2254,6 +2376,10 @@ static void pppoe_init(void)
 	load_config();
 
 	connlimit_loaded = triton_module_loaded("connlimit");
+
+	pppoe_nnle_handler.on_new_link = pppoe_on_add_link;
+	pppoe_nnle_handler.on_del_link = pppoe_on_del_link;
+	nnle_add_handler(&pppoe_nnle_handler);
 
 	triton_event_register_handler(EV_CONFIG_RELOAD, (triton_event_func)load_config);
 }

--- a/accel-pppd/ctrl/pppoe/pppoe.h
+++ b/accel-pppd/ctrl/pppoe/pppoe.h
@@ -9,6 +9,10 @@
 #include "rbtree.h"
 #include "crypto.h"
 
+#ifdef HAVE_VPP
+# include "vpputils.h"
+#endif /* HAVE_VPP */
+
 /* PPPoE codes */
 #define CODE_PADI           0x09
 #define CODE_PADO           0x07
@@ -100,6 +104,11 @@ struct pppoe_serv_t
 	unsigned int stopping:1;
 	unsigned int vlan_mon:1;
 	unsigned int is_vpppoe:1;
+	unsigned int is_vpppoe_lost:1;
+
+#ifdef HAVE_VPP
+	struct vpp_handler_t vpp_handler;
+#endif /* HAVE_VPP */
 };
 
 extern int conf_verbose;
@@ -121,6 +130,13 @@ extern unsigned long stat_filtered;
 
 extern pthread_rwlock_t serv_lock;
 extern struct list_head serv_list;
+
+struct monitored_link_list_entry_t {
+	struct list_head entry;
+	char *name;
+	char *opt;
+};
+extern struct list_head monitored_link_list;
 
 int mac_filter_check(const uint8_t *addr);
 void pppoe_server_start(const char *intf, void *client);

--- a/accel-pppd/ctrl/pppoe/pppoe.h
+++ b/accel-pppd/ctrl/pppoe/pppoe.h
@@ -105,6 +105,7 @@ struct pppoe_serv_t
 	unsigned int vlan_mon:1;
 	unsigned int is_vpppoe:1;
 	unsigned int is_vpppoe_lost:1;
+	unsigned int stop_cause;
 
 #ifdef HAVE_VPP
 	struct vpp_handler_t vpp_handler;

--- a/accel-pppd/include/new_link_event.h
+++ b/accel-pppd/include/new_link_event.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+ */
+
+#include "list.h"
+
+/* nnle: Netlink New Link Event */
+
+struct nnle_handler_t {
+	list_t entry;
+	void (*on_new_link)(const char *name);
+	void (*on_del_link)(const char *name);
+};
+
+void nnle_add_handler(struct nnle_handler_t *h);
+void nnle_del_handler(struct nnle_handler_t *h);

--- a/accel-pppd/include/vpputils.h
+++ b/accel-pppd/include/vpputils.h
@@ -17,5 +17,12 @@ void vpp_unlock();
 void vpp_get();
 void vpp_put();
 
+struct vpp_handler_t {
+	struct list_head entry;
+	void (*on_vpp_connection_lost)(struct vpp_handler_t *);
+};
+
+void vpp_register_handler(struct vpp_handler_t *h);
+void vpp_unregister_handler(struct vpp_handler_t *h);
 
 #endif /* VPPUTILS_H */

--- a/accel-pppd/libnetlink/new_link_event.c
+++ b/accel-pppd/libnetlink/new_link_event.c
@@ -1,0 +1,180 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+ */
+
+#include <linux/if.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+
+#include "triton.h"
+#include "ap_net.h"
+
+#include "new_link_event.h"
+
+static struct rtnl_handle rth;
+static struct triton_context_t ctx;
+static struct triton_md_handler_t hnd;
+
+LIST_HEAD(nnle_handlers);
+
+static void nnle_emit_callbacks(const char *name, int is_add)
+{
+	struct nnle_handler_t *e;
+	list_for_each_entry(e, &nnle_handlers, entry) {
+		if (is_add) {
+			e->on_new_link(name);
+		} else {
+			e->on_del_link(name);
+		}
+	}
+}
+
+static int nnle_nlmsg_handler(const struct sockaddr_nl *nladdr,
+		      struct nlmsghdr *hdr)
+{
+	struct rtattr *tb[IFLA_MAX+1];
+	struct ifinfomsg *ifi;
+	char ifname[IFNAMSIZ] = {0};
+
+	ifi = NLMSG_DATA(hdr);
+
+	parse_rtattr(tb, IFLA_MAX, IFLA_RTA(ifi), hdr->nlmsg_len - NLMSG_LENGTH(sizeof(struct ifinfomsg)));
+
+	if (tb[IFLA_IFNAME] && strlen(RTA_DATA(tb[IFLA_IFNAME])) < IFNAMSIZ)
+		strncpy(ifname, RTA_DATA(tb[IFLA_IFNAME]), IFNAMSIZ - 1);
+
+	if (hdr->nlmsg_type == RTM_NEWLINK && *(uint32_t *)RTA_DATA(tb[IFLA_OPERSTATE]) == IF_OPER_DOWN) {
+
+		struct ifreq ifr;
+		memset(&ifr, 0, sizeof(ifr));
+		strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
+
+		net->sock_ioctl(SIOCGIFFLAGS, &ifr);
+		if (ifr.ifr_flags) {
+			ifr.ifr_flags |= IFF_UP;
+			net->sock_ioctl(SIOCSIFFLAGS, &ifr);
+		}
+	}
+
+	if (hdr->nlmsg_type == RTM_NEWLINK && *(uint32_t *)RTA_DATA(tb[IFLA_OPERSTATE]) == IF_OPER_UP) {
+		nnle_emit_callbacks(ifname, 1);
+	} else if (hdr->nlmsg_type == RTM_DELLINK) {
+		nnle_emit_callbacks(ifname, 0);
+	}
+
+	return 0;
+}
+
+static int nnle_read(struct triton_md_handler_t *th)
+{
+	int status;
+	struct nlmsghdr* h;
+	struct sockaddr_nl nladdr;
+	struct iovec iov;
+	struct msghdr msg = {
+		.msg_name = &nladdr,
+		.msg_namelen = sizeof(nladdr),
+		.msg_iov = &iov,
+	.msg_iovlen = 1,
+	};
+	char buf[8192];
+
+	memset(&nladdr, 0, sizeof(nladdr));
+	nladdr.nl_family = AF_NETLINK;
+	nladdr.nl_pid = 0;
+	nladdr.nl_groups = 0;
+
+	iov.iov_base = buf;
+	iov.iov_len = sizeof(buf);
+
+	for (;;) {
+		status = recvmsg(rth.fd, &msg, 0);
+
+		if (status <= 0) {
+			if (errno == EINTR || errno == EAGAIN)
+				break;
+			return -1;
+		}
+
+		if (msg.msg_namelen != sizeof(nladdr))
+			return -1;
+
+		for (h = (struct nlmsghdr*)buf; status >= sizeof(*h);) {
+			int err;
+			int len = h->nlmsg_len;
+			int l = len - sizeof(*h);
+
+			if (l < 0 || len > status)
+				return -1;
+
+			err = nnle_nlmsg_handler(&nladdr, h);
+			if (err < 0)
+				return err;
+
+			status -= NLMSG_ALIGN(len);
+			h = (struct nlmsghdr*)((char*)h + NLMSG_ALIGN(len));
+		}
+
+		if (status)
+			return -1;
+	}
+
+	return 0;
+}
+
+static void nnle_close(struct triton_context_t *ctx)
+{
+	triton_md_disable_handler(&hnd, MD_MODE_READ);
+	triton_md_unregister_handler(&hnd, 1);
+	triton_context_unregister(ctx);
+}
+
+static void nnle_free(struct triton_context_t *ctx)
+{
+	triton_md_disable_handler(&hnd, MD_MODE_READ);
+	triton_md_unregister_handler(&hnd, 1);
+	triton_context_unregister(ctx);
+}
+
+static void nnle_ctx_switch(struct triton_context_t *ctx, void *arg)
+{
+	net = def_net;
+}
+
+__export void nnle_add_handler(struct nnle_handler_t *h) {
+	list_add(&h->entry, &nnle_handlers);
+}
+
+__export void nnle_del_handler(struct nnle_handler_t *h) {
+	list_del(&h->entry);
+}
+
+static void nnle_init()
+{
+	if (rtnl_open_byproto(&rth, 1 << (RTNLGRP_LINK - 1), NETLINK_ROUTE)) {
+		rth.fd = -1;
+		return;
+	}
+
+	fcntl(rth.fd, F_SETFL, O_NONBLOCK);
+	fcntl(rth.fd, F_SETFD, fcntl(rth.fd, F_GETFD) | FD_CLOEXEC);
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(&hnd, 0, sizeof(hnd));
+
+	ctx.close = nnle_close;
+	ctx.free = nnle_free;
+	ctx.before_switch = nnle_ctx_switch;
+	triton_context_register(&ctx, NULL);
+	hnd.fd = rth.fd;
+	hnd.read = nnle_read;
+	triton_md_register_handler(&ctx, &hnd);
+	triton_md_enable_handler(&hnd, MD_MODE_READ);
+	triton_context_wakeup(&ctx);
+}
+
+DEFINE_INIT(20, nnle_init);

--- a/accel-pppd/vpputils/vppiputils.c
+++ b/accel-pppd/vpputils/vppiputils.c
@@ -16,6 +16,8 @@
 
 DEFINE_VAPI_MSG_IDS_IP_API_JSON
 
+extern void vpp_check_error(vapi_error_e err);
+
 struct vpp_route_t {
 	struct list_head entry;
 
@@ -86,14 +88,26 @@ static vapi_error_e vpp_ip_ro_cb(struct vapi_ctx_s *ctx,
 								 bool is_last,
 								 vapi_payload_ip_route_add_del_reply *reply)
 {
-	return VAPI_OK;
+	return rv;
 }
 
 static int vpp_iproute(int is_add, int ifindex,
 								 in_addr_t dst, int mask)
 {
-	vapi_error_e verr;
-	vapi_msg_ip_route_add_del *req = vapi_alloc_ip_route_add_del(vpp_get_vapi(), 1);
+	vapi_error_e err = -1;
+	struct vapi_ctx_s *ctx;
+
+	vpp_lock();
+
+	ctx = vpp_get_vapi();
+	if (ctx == NULL) {
+		goto exit;
+	}
+
+	vapi_msg_ip_route_add_del *req = vapi_alloc_ip_route_add_del(ctx, 1);
+	if (req == NULL) {
+		goto exit;
+	}
 
 	req->payload.is_add = is_add;
 	req->payload.is_multipath = 0;
@@ -102,11 +116,12 @@ static int vpp_iproute(int is_add, int ifindex,
 	req->payload.route.prefix.len = mask;
 	req->payload.route.paths[0].sw_if_index = ifindex;
 
-	vpp_lock();
-	verr = vapi_ip_route_add_del(vpp_get_vapi(), req, vpp_ip_ro_cb, NULL);
-	vpp_unlock();
+	err = vapi_ip_route_add_del(ctx, req, vpp_ip_ro_cb, NULL);
+	vpp_check_error(err);
 
-	return !(verr == VAPI_OK);
+exit:
+	vpp_unlock();
+	return err;
 }
 
 __export int vpp_iproute_add_del(struct ap_session *ses, int is_add, int ifindex, in_addr_t src,
@@ -124,8 +139,20 @@ __export int vpp_iproute_add_del(struct ap_session *ses, int is_add, int ifindex
 
 static int vpp_ip6route(int is_add, int ifindex, const struct in6_addr *dst, int pref_len)
 {
-	vapi_error_e verr;
-	vapi_msg_ip_route_add_del *req = vapi_alloc_ip_route_add_del(vpp_get_vapi(), 1);
+	vapi_error_e err = -1;;
+	struct vapi_ctx_s *ctx;
+
+	vpp_lock();
+
+	ctx = vpp_get_vapi();
+	if (ctx == NULL) {
+		goto exit;
+	}
+
+	vapi_msg_ip_route_add_del *req = vapi_alloc_ip_route_add_del(ctx, 1);
+	if (req == NULL) {
+		goto exit;
+	}
 
 	req->payload.is_add = is_add;
 	req->payload.is_multipath = 0;
@@ -134,11 +161,12 @@ static int vpp_ip6route(int is_add, int ifindex, const struct in6_addr *dst, int
 	req->payload.route.prefix.len = pref_len;
 	req->payload.route.paths[0].sw_if_index = ifindex;
 
-	vpp_lock();
-	verr = vapi_ip_route_add_del(vpp_get_vapi(), req, vpp_ip_ro_cb, NULL);
-	vpp_unlock();
+	err = vapi_ip_route_add_del(ctx, req, vpp_ip_ro_cb, NULL);
+	vpp_check_error(err);
 
-	return !(verr == VAPI_OK);
+exit:
+	vpp_unlock();
+	return err;
 }
 
 __export int vpp_ip6route_add_del(struct ap_session *ses, int is_add, int ifindex, const struct in6_addr *dst, int pref_len, const struct in6_addr *gw, int proto, uint32_t prio)

--- a/accel-pppd/vpputils/vpppoe.c
+++ b/accel-pppd/vpputils/vpppoe.c
@@ -24,6 +24,8 @@ DEFINE_VAPI_MSG_IDS_PPPOE_API_JSON
 DEFINE_VAPI_MSG_IDS_FEATURE_API_JSON
 DEFINE_VAPI_MSG_IDS_INTERFACE_API_JSON
 
+extern void vpp_check_error(vapi_error_e err);
+
 static vapi_error_e vpppoe_s_session_add_reply_callback(struct vapi_ctx_s *ctx,
 														void *callback_ctx,
 														vapi_error_e rv,
@@ -42,11 +44,19 @@ static vapi_error_e vpppoe_s_session_add_reply_callback(struct vapi_ctx_s *ctx,
 
 __export int vpppoe_sync_add_pppoe_interface(uint8_t *client_mac, uint16_t session_id, uint32_t *sw_ifindex)
 {
-	vapi_error_e err;
+	vapi_error_e err = -1;
+	struct vapi_ctx_s *ctx;
 
-	vapi_msg_pppoe_add_del_session *req = vapi_alloc_pppoe_add_del_session(vpp_get_vapi());
+	vpp_lock();
+
+	ctx = vpp_get_vapi();
+	if (ctx == NULL) {
+		goto exit;
+	}
+
+	vapi_msg_pppoe_add_del_session *req = vapi_alloc_pppoe_add_del_session(ctx);
 	if (req == NULL) {
-		return -1;
+		goto exit;
 	}
 
 	req->payload.client_ip.af = ADDRESS_IP4;
@@ -56,10 +66,11 @@ __export int vpppoe_sync_add_pppoe_interface(uint8_t *client_mac, uint16_t sessi
 	req->payload.session_id = session_id;
 	req->payload.disable_fib = 1;
 
-	vpp_lock();
-	err = vapi_pppoe_add_del_session(vpp_get_vapi(), req, vpppoe_s_session_add_reply_callback, sw_ifindex);
-	vpp_unlock();
+	err = vapi_pppoe_add_del_session(ctx, req, vpppoe_s_session_add_reply_callback, sw_ifindex);
+	vpp_check_error(err);
 
+exit:
+	vpp_unlock();
 	return err;
 }
 
@@ -74,11 +85,19 @@ static vapi_error_e vpppoe_s_session_del_reply_callback(struct vapi_ctx_s *ctx,
 
 __export int vpppoe_sync_del_pppoe_interface(uint8_t *client_mac, uint16_t session_id)
 {
-	vapi_error_e err;
+	vapi_error_e err = -1;
+	struct vapi_ctx_s *ctx;
 
-	vapi_msg_pppoe_add_del_session *req = vapi_alloc_pppoe_add_del_session(vpp_get_vapi());
+	vpp_lock();
+
+	ctx = vpp_get_vapi();
+	if (ctx == NULL) {
+		goto exit;
+	}
+
+	vapi_msg_pppoe_add_del_session *req = vapi_alloc_pppoe_add_del_session(ctx);
 	if (req == NULL) {
-		return -1;
+		goto exit;
 	}
 
 	req->payload.client_ip.af = ADDRESS_IP4;
@@ -88,10 +107,11 @@ __export int vpppoe_sync_del_pppoe_interface(uint8_t *client_mac, uint16_t sessi
 	req->payload.session_id = session_id;
 	req->payload.disable_fib = 1;
 
-	vpp_lock();
-	err = vapi_pppoe_add_del_session(vpp_get_vapi(), req, vpppoe_s_session_del_reply_callback, NULL);
-	vpp_unlock();
+	err = vapi_pppoe_add_del_session(ctx, req, vpppoe_s_session_del_reply_callback, NULL);
+	vpp_check_error(err);
 
+exit:
+	vpp_unlock();
 	return err;
 }
 
@@ -106,10 +126,20 @@ static vapi_error_e vpppoe_set_feature_callback(struct vapi_ctx_s *ctx,
 
 __export int vpppoe_set_feature(uint32_t ifindex, int is_enabled, const char *feature, const char *arc)
 {
-	vapi_error_e err;
-	vapi_msg_feature_enable_disable *req = vapi_alloc_feature_enable_disable(vpp_get_vapi());
-	if (req == NULL)
-		return -1;
+	vapi_error_e err = -1;
+	struct vapi_ctx_s *ctx;
+
+	vpp_lock();
+
+	ctx = vpp_get_vapi();
+	if (ctx == NULL) {
+		goto exit;
+	}
+
+	vapi_msg_feature_enable_disable *req = vapi_alloc_feature_enable_disable(ctx);
+	if (req == NULL) {
+		goto exit;
+	}
 
 	strncpy((char *)req->payload.feature_name, feature, 63);
 	req->payload.feature_name[63] = 0;
@@ -119,10 +149,11 @@ __export int vpppoe_set_feature(uint32_t ifindex, int is_enabled, const char *fe
 	req->payload.sw_if_index = ifindex;
 	req->payload.enable = is_enabled;
 
-	vpp_lock();
-	err = vapi_feature_enable_disable(vpp_get_vapi(), req, vpppoe_set_feature_callback, NULL);
-	vpp_unlock();
+	err = vapi_feature_enable_disable(ctx, req, vpppoe_set_feature_callback, NULL);
+	vpp_check_error(err);
 
+exit:
+	vpp_unlock();
 	return err;
 }
 
@@ -140,7 +171,7 @@ static vapi_error_e vpppoe_dump_interface_name_callback(struct vapi_ctx_s *ctx,
 {
 	if (callback_ctx != NULL && reply != NULL && rv == VAPI_OK) {
 		vpppoe_dump_interface_name_ctx_t *ctx = (vpppoe_dump_interface_name_ctx_t *)callback_ctx;
-		strncpy(ctx->name, reply->interface_name, ctx->size > 64 ? 64 : ctx->size);
+		strncpy(ctx->name, (const char *)reply->interface_name, ctx->size > 64 ? 64 : ctx->size);
 		ctx->name[(ctx->size > 64 ? 64 : ctx->size) - 1] = 0;
 	}
 
@@ -149,22 +180,34 @@ static vapi_error_e vpppoe_dump_interface_name_callback(struct vapi_ctx_s *ctx,
 
 __export int vpppoe_dump_interface_name(uint32_t ifindex, char *name, size_t size)
 {
-	vapi_error_e err;
+	vapi_error_e err = -1;
+	struct vapi_ctx_s *ctx;
 
 	if (name == NULL || !size) {
 		return -1;
 	}
 
-	/* Allocated in stack - works only with sync VPP client */
-	vpppoe_dump_interface_name_ctx_t ctx = {name, size};
+	vpp_lock();
 
-	vapi_msg_sw_interface_dump *req = vapi_alloc_sw_interface_dump(vpp_get_vapi(), 0);
+	ctx = vpp_get_vapi();
+	if (ctx == NULL) {
+		goto exit;
+	}
+
+	/* Allocated in stack - works only with sync VPP client */
+	vpppoe_dump_interface_name_ctx_t dump_ctx = {name, size};
+
+	vapi_msg_sw_interface_dump *req = vapi_alloc_sw_interface_dump(ctx, 0);
+	if (req == NULL) {
+		goto exit;
+	}
 
 	req->payload.sw_if_index = ifindex;
 
-	vpp_lock();
-	err = vapi_sw_interface_dump(vpp_get_vapi(), req, vpppoe_dump_interface_name_callback, &ctx);
-	vpp_unlock();
+	err = vapi_sw_interface_dump(ctx, req, vpppoe_dump_interface_name_callback, &dump_ctx);
+	vpp_check_error(err);
 
-	return err != VAPI_OK;
+exit:
+	vpp_unlock();
+	return err;
 }

--- a/accel-pppd/vpputils/vpputils.c
+++ b/accel-pppd/vpputils/vpputils.c
@@ -21,15 +21,18 @@ struct vpp_connect_t
 	vapi_ctx_t vapi;
 	int rfcounter;
 	pthread_mutex_t lock_vpp;
+
+	struct list_head vpp_handlers;
 } vpp_connect;
 
 const char vpp_app_name[] = "accel-vpp";
 
 static void vpppoe_connect_to_vpp()
 {
+	vpp_connect.vapi = NULL;
 	vapi_error_e verr = vapi_ctx_alloc(&vpp_connect.vapi);
 
-	if (verr != VAPI_OK) {
+	if (verr != VAPI_OK || vpp_connect.vapi == NULL) {
 		vpp_connect.vapi = NULL;
 		return;
 	}
@@ -40,19 +43,21 @@ static void vpppoe_connect_to_vpp()
 		vpp_connect.vapi = NULL;
 		return;
 	}
-
-	pthread_mutex_init(&vpp_connect.lock_vpp, NULL);
 }
 
 void vpppoe_disconnect_from_vpp()
 {
-	pthread_mutex_destroy(&vpp_connect.lock_vpp);
-	vapi_disconnect(vpp_connect.vapi);
-	vapi_ctx_free(vpp_connect.vapi);
-	vpp_connect.vapi = NULL;
+	if (vpp_connect.vapi != NULL) {
+		vapi_disconnect(vpp_connect.vapi);
+		vapi_ctx_free(vpp_connect.vapi);
+		vpp_connect.vapi = NULL;
+	}
 }
 
 struct vapi_ctx_s * vpp_get_vapi() {
+	if (vpp_connect.vapi == NULL && __sync_fetch_and_and(&vpp_connect.rfcounter, 1)) {
+		vpppoe_connect_to_vpp();
+	}
 	return vpp_connect.vapi;
 }
 
@@ -66,18 +71,49 @@ void vpp_unlock() {
 
 void __export vpp_get()
 {
+	vpp_lock();
 	int rfc = __sync_fetch_and_add(&vpp_connect.rfcounter, 1);
 	if (!rfc)
 		vpppoe_connect_to_vpp();
+	vpp_unlock();
 }
 
 void __export vpp_put()
 {
+	vpp_lock();
 	int rfc = __sync_sub_and_fetch(&vpp_connect.rfcounter, 1);
 	if (!rfc)
 		vpppoe_disconnect_from_vpp();
+	vpp_unlock();
 }
 
+void __export vpp_register_handler(struct vpp_handler_t *h)
+{
+	if (h->on_vpp_connection_lost)
+		list_add_tail(&h->entry, &vpp_connect.vpp_handlers);
+}
+
+void __export vpp_unregister_handler(struct vpp_handler_t *h)
+{
+	list_del(&h->entry);
+}
+
+void vpp_call_on_vpp_connection_lost()
+{
+	struct vpp_handler_t *h = NULL;
+	list_for_each_entry(h, &vpp_connect.vpp_handlers, entry) {
+		if (h->on_vpp_connection_lost)
+			h->on_vpp_connection_lost(h);
+	}
+}
+
+void vpp_check_error(vapi_error_e err)
+{
+	if (vpp_connect.vapi && err >= VAPI_ECON_FAIL) {
+		vpppoe_disconnect_from_vpp();
+		vpp_call_on_vpp_connection_lost();
+	}
+}
 
 static void vpppoe_load_config(void)
 {
@@ -91,6 +127,8 @@ static void vpppoe_load_config(void)
 static void vpppoe_init()
 {
 	memset(&vpp_connect, 0, sizeof(vpp_connect));
+	pthread_mutex_init(&vpp_connect.lock_vpp, NULL);
+	INIT_LIST_HEAD(&vpp_connect.vpp_handlers);
 
 	vpppoe_load_config();
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Now, the PPPoE service starts/stops on the event of a new/del link using netlink. Added event on VPP connection lost - VPP-related PPPoE services are stopped. Added "list of monitored interfaces" - the list on which the PPPoE service would be started on a new link event. General PPPoE commands to add/del service on an interface, also adds or dels from "monitored list". To add an interface to the "monitored list", the interface should be in the config file or added with the command "pppoe interface add". To remove an interface from the "monitored list" - the command "pppoe interface del" is used.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
VD-1360

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Basic test and use case:
Launch VPP and accel-pppd with the vpp-cp option. "Crash" the VPP(just stop the VPP service) and restart it.
Accel-pppd should restart PPPoE service on the new VPP instance, and clients should eventually reconnect to the new service.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

I have read the CLA Document and I hereby sign the CLA