### PR TITLE
vpp: Added basic vpp policer configuration.

### DIFF
--- a/accel-pppd/CMakeLists.txt
+++ b/accel-pppd/CMakeLists.txt
@@ -183,6 +183,7 @@ IF (HAVE_VPP)
 				   vpputils/vpppoe.c
 				   vpputils/vppiputils.c
 				   vpputils/vppipv6layer.c
+				   vpputils/vpppolicer.c
 	)
 
 	TARGET_LINK_LIBRARIES(accel-pppd vapiclient vlibapi vlib)

--- a/accel-pppd/accel-ppp.conf
+++ b/accel-pppd/accel-ppp.conf
@@ -295,6 +295,14 @@ down-limiter=tbf
 #rate-multiplier=1
 #fwmark=1
 #rate-limit=2048/1024
+#vpp-policer-type=2r3c
+#vpp-cir-factor=0.8
+#vpp-cb-factor=1
+#vpp-eir-factor=1
+#vpp-eb-factor=0.2
+#vpp-conform-action=transmit
+#vpp-exceed-action=transmit
+#vpp-violate-action=drop
 verbose=1
 
 [cli]

--- a/accel-pppd/accel-ppp.conf.5
+++ b/accel-pppd/accel-ppp.conf.5
@@ -1255,6 +1255,30 @@ Due to accel-ppp operates with rates in kilobit basis if you send rates in diffe
 .TP
 .BI "rate-limit=" download_speed/upload_speed
 Specifies, should accel-ppp set default rate-limit for clients. Clients rate-limit will be overwritten by RADIUS filter attributes or chap-secrets rate-limit params.
+.TP
+.BI "vpp-policer-type=" 1r2c|1r3c|2r3c
+Specifies the type of policer used for VPP PPPoE sessions.
+.TP
+.BI "vpp-cir-factor=" n
+Specifies the factor for CIB used for policing of the VPP PPPoE session.
+.TP
+.BI "vpp-cb-factor=" n
+Specifies the factor for CB used for policing of the VPP PPPoE session.
+.TP
+.BI "vpp-eir-factor=" n
+Specifies the factor for EIR used for policing of the VPP PPPoE session. Used for 2r3c type policer.
+.TP
+.BI "vpp-eb-factor=" n
+Specifies the factor for EB used for policing of the VPP PPPoE session. Used for 1r3c and 2r3c type policer.
+.TP
+.BI "vpp-conform-action=" transmit|drop
+Specifies the action, what to do for packets that conform to the policer rule. "transmit" by default for all policer types.
+.TP
+.BI "vpp-exceed-action=" transmit|drop
+Specifies the action, what to do for packets that exceed the policer rule. Used for 2r3c and "exceed" packets are those packets that exceed the CIB rate, but feet to EIB and EB bucket is not full, "transmit" by default for 2r3c policer type.
+.TP
+.BI "vpp-violate-action=" transmit|drop
+Specifies the action to take for packets that violate the policer rule. By default is "drop" for all policer types.
 .SH [cli]
 .br
 Configuration of the command line interface.

--- a/accel-pppd/ctrl/pppoe/pppoe.c
+++ b/accel-pppd/ctrl/pppoe/pppoe.c
@@ -41,6 +41,7 @@
 #include "vpputils.h"
 #include "vpppoe.h"
 #include "vppiputils.h"
+#include "vpppolicer.h"
 #include "new_link_event.h"
 
 #define SID_MAX 65536
@@ -247,6 +248,7 @@ int pppoe_terminate(struct ap_session *ses, int hard) {
 
 	if (ppp->is_vpppoe && !conn->serv->is_vpppoe_lost) {
 		vpp_iproute_flush(ses);
+		vpppolicer_remove_limiter(ses);
 		vpppoe_sync_del_pppoe_interface(conn->addr, conn->sid);
 	}
 

--- a/accel-pppd/include/ap_session.h
+++ b/accel-pppd/include/ap_session.h
@@ -129,6 +129,11 @@ struct ap_session
 	struct list_head vpp_routes;
 	int (*vpp_nd_recv)(struct ap_session *, const void *, size_t, struct in6_addr *);
 	int (*vpp_dhcpv6_recv)(struct ap_session *, const void *, size_t, struct in6_addr *, unsigned short);
+
+	uint32_t vpppolicer_down;
+	uint64_t vpppolicer_down_burst;
+	uint32_t vpppolicer_up;
+	uint64_t vpppolicer_up_burst;
 };
 
 struct ap_session_stat

--- a/accel-pppd/include/vpppolicer.h
+++ b/accel-pppd/include/vpppolicer.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+ */
+
+int vpppolicer_install_limiter(struct ap_session *ses, int down_speed, int down_burst, int up_speed, int up_burst);
+int vpppolicer_remove_limiter(struct ap_session *ses);

--- a/accel-pppd/shaper/limiter.c
+++ b/accel-pppd/shaper/limiter.c
@@ -21,6 +21,8 @@
 #include "tc_core.h"
 #include "libnetlink.h"
 
+#include "vpppolicer.h"
+
 static int qdisc_tbf(struct qdisc_opt *qopt, struct nlmsghdr *n)
 {
 	struct tc_tbf_qopt opt;
@@ -540,6 +542,16 @@ static int remove_htb_ifb(struct rtnl_handle *rth, int ifindex, int priority)
 
 int install_limiter(struct ap_session *ses, int down_speed, int down_burst, int up_speed, int up_burst, int idx)
 {
+#ifdef HAVE_VPP
+	if (ses->non_dev_ppp_fixup != NULL) {
+		down_speed = down_speed * 1000 / 8;
+		down_burst = down_burst ? down_burst : conf_down_burst_factor * down_speed;
+		up_speed = up_speed * 1000 / 8;
+		up_burst = up_burst ? up_burst : conf_up_burst_factor * up_speed;
+		return vpppolicer_install_limiter(ses, down_speed, down_burst, up_speed, up_burst);
+	}
+#endif
+
 	struct rtnl_handle *rth = net->rtnl_get();
 	int r = 0;
 
@@ -596,6 +608,12 @@ int install_limiter(struct ap_session *ses, int down_speed, int down_burst, int 
 
 int remove_limiter(struct ap_session *ses, int idx)
 {
+#ifdef HAVE_VPP
+	if (ses->non_dev_ppp_fixup != NULL) {
+		return vpppolicer_remove_limiter(ses);
+	}
+#endif
+
 	struct rtnl_handle *rth = net->rtnl_get();
 
 	if (!rth) {

--- a/accel-pppd/vpputils/vpppolicer.c
+++ b/accel-pppd/vpputils/vpppolicer.c
@@ -1,0 +1,341 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2025 by VyOS Networks
+ * Andrii Melnychenko a.melnychenko@vyos.io
+ */
+
+#include <vapi/vapi.h>
+#include <vapi/vpe.api.vapi.h>
+#include <vapi/policer.api.vapi.h>
+
+#include <stdio.h>
+
+#include "ap_session.h"
+#include "triton.h"
+#include "events.h"
+#include "vpputils.h"
+#include "vpppoe.h"
+
+#include "vpppolicer.h"
+
+DEFINE_VAPI_MSG_IDS_POLICER_API_JSON
+
+#define POLICER_NAME_MAX_LEN 64
+
+extern void vpp_check_error(vapi_error_e err);
+
+static uint32_t s_vpp_policer_type = SSE2_QOS_POLICER_TYPE_API_2R3C_RFC_2698;
+static double s_cir_factor = 0.8;
+static double s_cb_factor = 1;
+static double s_eir_factor = 1;
+static double s_eb_factor = 0.2;
+static uint32_t s_conform_action = SSE2_QOS_ACTION_API_TRANSMIT;
+static uint32_t s_exceed_action = SSE2_QOS_ACTION_API_TRANSMIT;
+static uint32_t s_violate_action = SSE2_QOS_ACTION_API_DROP;
+
+static vapi_error_e vpppolicer_set_input_callback(struct vapi_ctx_s *ctx,
+												void *callback_ctx,
+												vapi_error_e rv,
+												bool is_last,
+												vapi_payload_policer_input_reply *reply)
+{
+	return rv;
+}
+
+__export int vpppolicer_set_input(int is_add, uint32_t ifindex, const char *policer_name)
+{
+	vapi_error_e err = -1;
+	struct vapi_ctx_s *ctx;
+
+	vpp_lock();
+
+	ctx = vpp_get_vapi();
+	if (ctx == NULL) {
+		goto exit;
+	}
+
+	vapi_msg_policer_input *req = vapi_alloc_policer_input(ctx);
+	if (req == NULL) {
+		goto exit;
+	}
+
+	req->payload.apply = is_add;
+	strncpy((char *)req->payload.name, policer_name, sizeof(req->payload.name) - 1);
+	req->payload.name[sizeof(req->payload.name) - 1] = 0;
+	req->payload.sw_if_index = ifindex;
+
+	err = vapi_policer_input(ctx, req, vpppolicer_set_input_callback, NULL);
+	vpp_check_error(err);
+
+exit:
+	vpp_unlock();
+	return err;
+}
+
+static vapi_error_e vpppolicer_set_output_callback(struct vapi_ctx_s *ctx,
+												void *callback_ctx,
+												vapi_error_e rv,
+												bool is_last,
+												vapi_payload_policer_output_reply *reply)
+{
+	return rv;
+}
+
+__export int vpppolicer_set_output(int is_add, uint32_t ifindex, const char *policer_name)
+{
+	vapi_error_e err = -1;
+	struct vapi_ctx_s *ctx;
+
+	vpp_lock();
+
+	ctx = vpp_get_vapi();
+	if (ctx == NULL) {
+		goto exit;
+	}
+
+	vapi_msg_policer_output *req = vapi_alloc_policer_output(ctx);
+	if (req == NULL) {
+		goto exit;
+	}
+
+	req->payload.apply = is_add;
+	strncpy((char *)req->payload.name, policer_name, sizeof(req->payload.name) - 1);
+	req->payload.name[sizeof(req->payload.name) - 1] = 0;
+	req->payload.sw_if_index = ifindex;
+
+	err = vapi_policer_output(ctx, req, vpppolicer_set_output_callback, NULL);
+	vpp_check_error(err);
+
+exit:
+	vpp_unlock();
+	return err;
+}
+
+static vapi_error_e vpppolicer_add_del_callback(struct vapi_ctx_s *ctx,
+												void *callback_ctx,
+												vapi_error_e rv,
+												bool is_last,
+												vapi_payload_policer_add_del_reply *reply)
+{
+	return rv;
+}
+
+static int vpppolicer_add_del(int is_add, const char *policer_name, uint32_t cir_kbits, uint64_t cb_bits)
+{
+	vapi_error_e err = -1;
+	struct vapi_ctx_s *ctx;
+
+	vpp_lock();
+
+	ctx = vpp_get_vapi();
+	if (ctx == NULL) {
+		goto exit;
+	}
+
+	vapi_msg_policer_add_del *req = vapi_alloc_policer_add_del(ctx);
+	if (req == NULL) {
+		goto exit;
+	}
+
+	req->payload.is_add = is_add;
+	strncpy((char *)req->payload.name, policer_name, sizeof(req->payload.name) - 1);
+	req->payload.name[sizeof(req->payload.name) - 1] = 0;
+
+	req->payload.cir = cir_kbits * s_cir_factor;
+	req->payload.cb = cb_bits * s_cb_factor;
+	req->payload.eir = cir_kbits * s_eir_factor;
+	req->payload.eb = cb_bits * s_eb_factor;
+
+	req->payload.rate_type = SSE2_QOS_RATE_API_KBPS;
+	req->payload.round_type = SSE2_QOS_ROUND_API_TO_CLOSEST;
+	req->payload.type = s_vpp_policer_type;
+
+	req->payload.conform_action.type = s_conform_action;
+	req->payload.exceed_action.type = s_exceed_action;
+	req->payload.violate_action.type = s_violate_action;
+
+	req->payload.color_aware = 0;
+
+	err = vapi_policer_add_del(ctx, req, vpppolicer_add_del_callback, NULL);
+	vpp_check_error(err);
+
+exit:
+	vpp_unlock();
+	return err;
+}
+
+static void vpppolicer_generate_name(char *name, size_t size, struct ap_session *ses, uint32_t rate, uint64_t burst, int is_up)
+{
+	snprintf(name, size, "vyos_%d_%d_%ld_%s", ses->vpp_sw_if_index, rate, burst, is_up ? "up" : "down");
+}
+
+__export int vpppolicer_install_limiter(struct ap_session *ses, int down_speed, int down_burst, int up_speed, int up_burst)
+{
+	int ret = 0;
+	char policer_input[POLICER_NAME_MAX_LEN] = {};
+	char policer_output[POLICER_NAME_MAX_LEN] = {};
+
+	/* convert rate to kbits/s and burst to bits */
+	down_speed = down_speed * 8 / 1000;
+	down_burst = down_burst * 8;
+	up_speed = up_speed * 8 / 1000;
+	up_burst = up_burst * 8;
+
+	/* Remove previously installed limiter, if exists */
+	vpppolicer_remove_limiter(ses);
+
+	if (down_speed) {
+		vpppolicer_generate_name(policer_output, POLICER_NAME_MAX_LEN - 1, ses, down_speed, down_burst, 0);
+		vpppolicer_add_del(1, policer_output, down_speed, down_burst);
+		ret = vpppolicer_set_output(1, ses->vpp_sw_if_index, policer_output);
+		if (ret) {
+			vpppolicer_add_del(0, policer_output, down_speed, down_burst);
+			goto exit;
+		}
+
+		ses->vpppolicer_down = down_speed;
+		ses->vpppolicer_down_burst = down_burst;
+	}
+
+	if (up_speed) {
+		vpppolicer_generate_name(policer_input, POLICER_NAME_MAX_LEN - 1, ses, up_speed, up_burst, 1);
+		vpppolicer_add_del(1, policer_input, up_speed, up_burst);
+		ret = vpppolicer_set_input(1, ses->vpp_sw_if_index, policer_input);
+		if (ret) {
+			vpppolicer_add_del(0, policer_input, up_speed, up_burst);
+			if (down_speed) {
+				vpppolicer_set_output(0, ses->vpp_sw_if_index, policer_output);
+				vpppolicer_add_del(0, policer_output, down_speed, down_burst);
+				ses->vpppolicer_down = 0;
+				ses->vpppolicer_down_burst = 0;
+			}
+			goto exit;
+		}
+
+		vpppoe_set_feature(ses->vpp_sw_if_index, 1, "policer-input", "ip4-unicast");
+		vpppoe_set_feature(ses->vpp_sw_if_index, 1, "policer-input", "ip6-unicast");
+		vpppoe_set_feature(ses->vpp_sw_if_index, 1, "policer-input", "ip4-multicast");
+		vpppoe_set_feature(ses->vpp_sw_if_index, 1, "policer-input", "ip6-multicast");
+
+		ses->vpppolicer_up = up_speed;
+		ses->vpppolicer_up_burst = up_burst;
+	}
+
+exit:
+	return ret;
+}
+
+__export int vpppolicer_remove_limiter(struct ap_session *ses)
+{
+	int ret = 0;
+	char policer_input[64] = {};
+	char policer_output[64] = {};
+
+	if (ses->vpppolicer_down) {
+		vpppolicer_generate_name(policer_output, POLICER_NAME_MAX_LEN - 1, ses, ses->vpppolicer_down, ses->vpppolicer_down_burst, 0);
+		ret = vpppolicer_set_output(0, ses->vpp_sw_if_index, policer_output);
+		if (ret)
+			goto exit;
+		vpppolicer_add_del(0, policer_output, ses->vpppolicer_down, ses->vpppolicer_down_burst);
+		ses->vpppolicer_down = 0;
+		ses->vpppolicer_down_burst = 0;
+	}
+
+	if (ses->vpppolicer_up) {
+		vpppolicer_generate_name(policer_input, POLICER_NAME_MAX_LEN - 1, ses, ses->vpppolicer_up, ses->vpppolicer_up_burst, 1);
+		ret = vpppolicer_set_input(0, ses->vpp_sw_if_index, policer_input);
+		if (ret)
+			goto exit;
+		vpppolicer_add_del(0, policer_input, ses->vpppolicer_up, ses->vpppolicer_up_burst);
+
+		vpppoe_set_feature(ses->vpp_sw_if_index, 0, "policer-input", "ip4-unicast");
+		vpppoe_set_feature(ses->vpp_sw_if_index, 0, "policer-input", "ip6-unicast");
+		vpppoe_set_feature(ses->vpp_sw_if_index, 0, "policer-input", "ip4-multicast");
+		vpppoe_set_feature(ses->vpp_sw_if_index, 0, "policer-input", "ip6-multicast");
+
+		ses->vpppolicer_up = 0;
+		ses->vpppolicer_up_burst = 0;
+	}
+
+exit:
+	return ret;
+}
+
+static uint32_t vpppolicer_parse_action(const char *opt)
+{
+	uint32_t ret = SSE2_QOS_ACTION_API_DROP;
+
+	if (!strncmp(opt, "transmit", sizeof("transmit") - 1)) {
+		ret = SSE2_QOS_ACTION_API_TRANSMIT;
+	} /* TODO: add transmit and mark? */
+
+	return ret;
+}
+
+static void vpppolicer_load_config(void)
+{
+	char *opt;
+
+	opt = conf_get_opt("shaper", "vpp-policer-type");
+	if (opt) {
+		s_conform_action = SSE2_QOS_ACTION_API_TRANSMIT;
+		s_exceed_action = SSE2_QOS_ACTION_API_DROP;
+		s_violate_action = SSE2_QOS_ACTION_API_DROP;
+
+		s_cir_factor = 1;
+		s_cb_factor = 1;
+		s_eir_factor = 0;
+		s_eb_factor = 0;
+
+		if (!strncmp(opt, "1r2c", sizeof("1r2c") - 1)) {
+			s_vpp_policer_type = SSE2_QOS_POLICER_TYPE_API_1R2C;
+		} else if (!strncmp(opt, "1r3c", sizeof("1r3c") - 1)) {
+			s_vpp_policer_type = SSE2_QOS_POLICER_TYPE_API_1R3C_RFC_2697;
+			s_cb_factor = 0.8;
+			s_eb_factor = 0.2;
+		} else if (!strncmp(opt, "2r3c", sizeof("2r3c") - 1)) {
+			s_vpp_policer_type = SSE2_QOS_POLICER_TYPE_API_2R3C_RFC_2698;
+			s_cir_factor = 0.8;
+			s_eir_factor = 1;
+			s_eb_factor = 0.2;
+			s_exceed_action = SSE2_QOS_ACTION_API_TRANSMIT;
+		}
+	}
+
+	opt = conf_get_opt("shaper", "vpp-cir-factor");
+	if (opt)
+		s_cir_factor = atof(opt);
+
+	opt = conf_get_opt("shaper", "vpp-cb-factor");
+	if (opt)
+		s_cb_factor = atof(opt);
+
+	opt = conf_get_opt("shaper", "vpp-eir-factor");
+	if (opt)
+		s_eir_factor = atof(opt);
+
+	opt = conf_get_opt("shaper", "vpp-eb-factor");
+	if (opt)
+		s_eb_factor = atof(opt);
+
+	opt = conf_get_opt("shaper", "vpp-conform-action");
+	if (opt)
+		s_conform_action = vpppolicer_parse_action(opt);
+
+	opt = conf_get_opt("shaper", "vpp-exceed-action");
+	if (opt)
+		s_exceed_action = vpppolicer_parse_action(opt);
+
+	opt = conf_get_opt("shaper", "vpp-violate-action");
+	if (opt)
+		s_violate_action = vpppolicer_parse_action(opt);
+}
+
+static void vpppolicer_init()
+{
+	vpppolicer_load_config();
+
+	triton_event_register_handler(EV_CONFIG_RELOAD, (triton_event_func)vpppolicer_load_config);
+}
+
+DEFINE_INIT(50, vpppolicer_init);


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
The vpp-policer works as part of accel-ppp's shaper. If pppoe session is a VPP PPPoE session, then the vpp-policer
 is used instead of the kernel's qdisc.

Added additional options in "shaper" settings:
vpp-policer-type - [1r2c, 1r3c, 2r3c], type of vpp police.
vpp-cir-factor - factor that is used during vpp policer install - cir * vpp-cir-factor.
vpp-cb-factor - factor of burst - cb *  vpp-cb-factor.
vpp-eir-factor - similar to cir factor - eir * vpp-eir-factor. 
vpp-eb-factor - similar to cb factor - eb * vpp-eb-factor.
vpp-conform-action, vpp-exceed-action, and vpp-violate-action - action on policer, possible values "transmit" and "drop".
 
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
VD-1398

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Configure limits, e.g, with RADIUS:
```
client-1	Cleartext-Password := "client-1"
   	Filter-Id=10000/20000,
...
```

Add shaper and vpp-pppoe configuration to accel-pppd:
```
[pppoe]
interface=eth0,vpp-cp=true
...
[shaper]
vpp-policer-type=2r3c
...
```

Connect the PPPoE client and check speed e.g, with iperf3.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
