### PR TITLE
T8439: L2TP - Add validation checks for Hidden AVP lengths

### DIFF
--- a/accel-pppd/ctrl/l2tp/packet.c
+++ b/accel-pppd/ctrl/l2tp/packet.c
@@ -419,6 +419,8 @@ int l2tp_recv(int fd, struct l2tp_packet_t **p, struct in_pktinfo *pkt_info,
 			}
 
 			if (avp->flags & L2TP_AVP_FLAG_H) {
+				uint16_t orig_attr_len;
+
 				if (!RV) {
 					if (conf_verbose)
 						log_warn("l2tp: incorrect avp received (type=%i, H=1, but Random-Vector is not received)\n", ntohs(avp->type));
@@ -434,7 +436,22 @@ int l2tp_recv(int fd, struct l2tp_packet_t **p, struct in_pktinfo *pkt_info,
 				if (decode_avp(avp, RV, secret, secret_len) < 0)
 					goto out_err;
 
-				orig_avp_len = ntohs(*(uint16_t *)avp->val) + sizeof(*avp);
+				/* Extract original attribute length from the first two bytes of the decrypted value */
+				memcpy(&orig_attr_len, avp->val, sizeof(orig_attr_len));
+				orig_attr_len = ntohs(orig_attr_len);
+				if (orig_attr_len < sizeof(uint16_t)) {
+					if (conf_verbose)
+						log_warn("l2tp: hidden avp rejected: invalid orig_attr_len=%hu (too small)\n", orig_attr_len);
+					goto out_err;
+				}
+
+				size_t total_avp_len = (size_t)orig_attr_len + sizeof(*avp);
+				if (total_avp_len > avp_len) {
+					if (conf_verbose)
+						log_warn("l2tp: hidden avp rejected: orig_attr_len=%hu (total %zu) exceeds avp_len=%hu\n", orig_attr_len, total_avp_len, avp_len);
+					goto out_err;
+				}
+				orig_avp_len = total_avp_len;
 				orig_avp_val = avp->val + sizeof(uint16_t);
 			} else {
 				orig_avp_len = avp_len;


### PR DESCRIPTION
Fix for memory related OOB read/copy and integer overflow issues for the case when invalid lengths are received in the L2TP packets inside hidden AVPs. Added validation checks to handle invalid length values gracefully.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Added validation check for the below scenarios:
- decrypted attribute length is too short ( < 2 Bytes)
- decoded total AVP length (decrypted attribute length + header length) is too large

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8439

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
TESTED AS BELOW:
Create the config file `/etc/accel-ppp-l2tp-test.conf` with below contents:
```
[modules]
log_file
l2tp
auth_mschap_v2
auth_chap_md5
auth_pap
chap-secrets
ippool

[core]
log-error=/var/log/accel-ppp/core.log
thread-count=2

[common]
# Allow any login (skip strict auth check — easier for local testing)
noauth=1

[ppp]
verbose=1
ipv4=require
ipv6=deny
lcp-echo-interval=0

[l2tp]
verbose=1
avp_permissive=1

# THE TWO CRITICAL LINES FOR REPRODUCING THE BUG:
secret=mytunnelsecret
hide-avps=1

[ippool]
gw-ip-address=10.99.0.1
10.99.0.2-10.99.0.254

[client-ip-range]
127.0.0.0/8

[chap-secrets]
chap-secrets=/etc/ppp/chap-secrets

[log]
log-file=/var/log/accel-ppp/accel-ppp.log
log-emerg=/var/log/accel-ppp/emerg.log
copy=1
level=5

```
Run the PoC file shared in the jira using below cmd :
`python3 /tmp/poc_l2tp_hidden_avp.py 127.0.0.1 1701 mytunnelsecret`

Start accel-pppd
`sudo /usr/sbin/accel-pppd -c /etc/accel-ppp-l2tp-test.conf`

Tail the logs:
`sudo tail -f /var/log/accel-ppp/*.log`

_**LOGS WITHOUT FIX:**_
#### Using correct secret : mytunnelsecret
[2026-03-27 20:18:53]:  warn: l2tp: incorrect avp received (type=7, H=1, must be 0)
[2026-03-27 20:18:53]:  info: l2tp: recv [L2TP tid=0 sid=0 Ns=0 Nr=0 <Message-Type Start-Ctrl-Conn-Request> <Random-Vector> <Host-Name 7?0E??????I??>]
[2026-03-27 20:18:53]:  info: l2tp: handling SCCRQ from 127.0.0.1
[2026-03-27 20:18:53]: error: l2tp: impossible to handle SCCRQ from 127.0.0.1: no Assigned-Tunnel-ID or Assigned-Connection-ID present in message

#### Using incorrect secret : abc
[2026-03-27 20:24:12]:  warn: l2tp: incorrect avp received (type=7, H=1, must be 0)
H ?I?x?ƭY>] 20:24:12]:  info: l2tp: recv [L2TP tid=0 sid=0 Ns=0 Nr=0 <Message-Type Start-Ctrl-Conn-Request> <Random-Vector> <Host-Name :
[2026-03-27 20:24:12]:  info: l2tp: handling SCCRQ from 127.0.0.1
[2026-03-27 20:24:12]: error: l2tp: impossible to handle SCCRQ from 127.0.0.1: no Assigned-Tunnel-ID or Assigned-Connection-ID present in message

_**LOGS WITH FIX:**_
#### Using correct secret : mytunnelsecret
[2026-03-27 21:12:37]:  warn: l2tp: incorrect avp received (type=7, H=1, must be 0)
[2026-03-27 21:12:37]:  warn: l2tp: hidden avp rejected: orig_attr_len=17355 (total 17361) exceeds avp_len=22

#### Using incorrect secret : abc
[2026-03-27 21:15:52]:  warn: l2tp: incorrect avp received (type=7, H=1, must be 0)
[2026-03-27 21:15:52]:  warn: l2tp: hidden avp rejected: orig_attr_len=617 (total 623) exceeds avp_len=22

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
