### PR TITLE
VD3431: Refactored Netlink New Link Event handler

### DIFF
--- a/accel-pppd/libnetlink/new_link_event.c
+++ b/accel-pppd/libnetlink/new_link_event.c
@@ -47,20 +47,15 @@ static int nnle_nlmsg_handler(const struct sockaddr_nl *nladdr,
 	if (tb[IFLA_IFNAME] && strlen(RTA_DATA(tb[IFLA_IFNAME])) < IFNAMSIZ)
 		strncpy(ifname, RTA_DATA(tb[IFLA_IFNAME]), IFNAMSIZ - 1);
 
-	if (hdr->nlmsg_type == RTM_NEWLINK && *(uint32_t *)RTA_DATA(tb[IFLA_OPERSTATE]) == IF_OPER_DOWN) {
-
-		struct ifreq ifr;
-		memset(&ifr, 0, sizeof(ifr));
-		strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
-
-		net->sock_ioctl(SIOCGIFFLAGS, &ifr);
-		if (ifr.ifr_flags) {
-			ifr.ifr_flags |= IFF_UP;
-			net->sock_ioctl(SIOCSIFFLAGS, &ifr);
-		}
-	}
-
-	if (hdr->nlmsg_type == RTM_NEWLINK && *(uint32_t *)RTA_DATA(tb[IFLA_OPERSTATE]) == IF_OPER_UP) {
+	/*
+	  Note: during interface initialization, there are several RTM_NEWLINK messages, so we need to "handle"
+	  The interface is when the system configures it.
+	  A bit hacky way - overall we want to call handlers when there is a new interface, if the operstate
+	  is not DOWN(it could be *UNKNOWN*) and interface info change is UP.
+	  That's how we can handle different interfaces provided by VPP - e.g., LCP tap and LCP bond.
+	 */
+	if (hdr->nlmsg_type == RTM_NEWLINK && (*(uint32_t *)RTA_DATA(tb[IFLA_OPERSTATE]) != IF_OPER_DOWN) &&
+	    (ifi->ifi_flags & ifi->ifi_change) & IFF_UP) {
 		nnle_emit_callbacks(ifname, 1);
 	} else if (hdr->nlmsg_type == RTM_DELLINK) {
 		nnle_emit_callbacks(ifname, 0);


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Now, the handler would check ifinfomsg to make a new link event.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
VD3431

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
1. Launch VPP with a bond interface and create a PPPoE control plane with the bond interface:
```
vpp# create bond mode xor
vpp# set interface state BondEthernet0 up
vpp# bond add BondEthernet0 enp7s0
vpp# bond add BondEthernet0 enp8s0

vpp# lcp create BondEthernet0 host-if vpptap0
vpp# create pppoe map dp BondEthernet0 cp tap4096
```

2. Start the accel-ppp-ng with PPPoE service on the VPP interface:
```
sudo ./accel-pppd/accel-pppd -c ../accel-ppp.nlcp.conf 
[2026-03-31 12:42:46.055] accel-ppp version 64e351d
[2026-03-31 12:42:46.082] failed to load vlan_mon module
[2026-03-31 12:42:46.083] libnetlink: RTNETLINK answers: No such file or directory
[2026-03-31 12:42:46.083] genl: error talking to kernel
[2026-03-31 12:42:46.083] vlan_mon: kernel module is not loaded
....
```

3. "restart" VPP, simulating VPP's crash, and check that the PPPoE service is restarted:
```
...
[2026-03-31 12:44:42.306] pppoe: delete link event received, stopping the service on: vpptap0 ifindex 180
[2026-03-31 12:44:45.256] pppoe: new link event received, starting the service on: vpptap0 with options ",vpp-cp=true"
...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
