### PR TITLE
ci: align push triggers with default branch and bump checkout to v4

### DIFF
--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - current
 
 jobs:
   Build-in-VM:
@@ -33,7 +33,7 @@ jobs:
           git build-essential cmake gcc linux-headers-`uname -r`
           libpcre2-dev libssl-dev liblua5.1-0-dev kmod
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: mkdir build
@@ -126,7 +126,7 @@ jobs:
           sed 's/linux-headers-//'` >> $GITHUB_ENV;
           cat $GITHUB_ENV
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: mkdir build
@@ -191,7 +191,7 @@ jobs:
           sed 's/linux-headers-//'` >> $GITHUB_ENV;
           cat $GITHUB_ENV
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: mkdir build
@@ -225,7 +225,7 @@ jobs:
         run: >
           apk update && apk add --no-cache git cmake make g++ pcre2-dev libressl-dev linux-headers libucontext-dev lua5.1-dev
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: mkdir build

--- a/.github/workflows/run-tests-32bit.yml
+++ b/.github/workflows/run-tests-32bit.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - current
 
 jobs:
   Test-in-Alpine-x86-32:

--- a/.github/workflows/run-tests-bigendian.yml
+++ b/.github/workflows/run-tests-bigendian.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - current
 
 jobs:
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - current
 
 jobs:
   Test-in-Qemu:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,7 +18,7 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: SonarCloud Scan


### PR DESCRIPTION
## Change summary

Two small CI cleanups bundled:

1. **Fix push triggers.** The default branch of this fork is `current`, but `build-and-run.yml`, `run-tests.yml`, `run-tests-32bit.yml`, and `run-tests-bigendian.yml` were still push-triggered on `master`. Pushes to `current` never fired those workflows — only `pull_request` + `workflow_dispatch` were exercising them. Changed all four to trigger on `current`.
2. **Bump `actions/checkout` v3 → v4.** Five occurrences (4 in `build-and-run.yml`, 1 in `sonarcloud.yml`). Every other workflow in the repo already pins v4; this brings the outliers in line and avoids the Node 16 deprecation warnings in GHA logs.

No behavioural changes in what the workflows do — just making sure they fire when they should and using a non-deprecated action.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code style update (formatting, renaming)

## How to test

- Push a commit to `current` — `build-and-run`, `run-tests`, `run-tests-32bit`, `run-tests-bigendian` should now fire (they didn't before).
- PR-triggered runs (this PR) should still work exactly as before.
- No `Node.js 16 actions are deprecated` warning in any workflow's checkout step.
