### PR TITLE
ci: ignore .worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 *.swp
 scripts
+.worktrees/


### PR DESCRIPTION
## Change summary

Add `.worktrees/` to `.gitignore`. Contributors using `git worktree add .worktrees/<branch>` for per-branch isolation will no longer see the worktree dirs show up in `git status`, and can't accidentally `git add` them.

One-line change, no behavioural impact.

## Types of changes

- [x] Other (please describe): repo hygiene
